### PR TITLE
UHF-X: Return the missing quote to wysiwyg by fixing the broken configuration

### DIFF
--- a/conf/cmi/editor.editor.full_html.yml
+++ b/conf/cmi/editor.editor.full_html.yml
@@ -34,7 +34,7 @@ settings:
         -
           name: Media
           items:
-            1: quote
+            - quote
         -
           name: Links
           items:

--- a/conf/cmi/filter.format.full_html.yml
+++ b/conf/cmi/filter.format.full_html.yml
@@ -25,7 +25,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type> <li class> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class="">'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class=""> <ol start type> <li class=""> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class="">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:
@@ -62,8 +62,8 @@ filters:
     weight: -39
     settings:
       default_view_mode: default
-      allowed_view_modes: {  }
       allowed_media_types: {  }
+      allowed_view_modes: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor


### PR DESCRIPTION
To test:

1. `make drush-cim && make drush-cr`
2. Check that there is now quote on the wysiwyg blocks that wasn't there before.