### PR TITLE
UHF-3451: UHF-3451: Return the configuration for hide_description fie…

### DIFF
--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -57,7 +57,7 @@ content:
   address:
     type: readonly_field_widget
     region: content
-    weight: 14
+    weight: 15
     settings:
       label: above
       formatter_type: null
@@ -67,7 +67,7 @@ content:
   address_postal:
     type: readonly_field_widget
     region: content
-    weight: 16
+    weight: 17
     settings:
       label: above
       formatter_type: null
@@ -77,7 +77,7 @@ content:
   call_charge_info:
     type: readonly_field_widget
     region: content
-    weight: 15
+    weight: 16
     settings:
       label: above
       formatter_type: null
@@ -106,7 +106,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 27
+    weight: 24
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -124,7 +124,7 @@ content:
     third_party_settings: {  }
     region: content
   field_hs_educational_mission:
-    weight: 31
+    weight: 28
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -134,7 +134,7 @@ content:
     type: select2_entity_reference
     region: content
   field_hs_emphasis:
-    weight: 30
+    weight: 27
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -145,7 +145,7 @@ content:
     region: content
   field_lower_content:
     type: paragraphs
-    weight: 28
+    weight: 25
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -162,20 +162,20 @@ content:
         duplicate: duplicate
     third_party_settings: {  }
     region: content
+  field_metatags:
+    weight: 23
+    settings:
+      sidebar: false
+    third_party_settings: {  }
+    type: metatag_firehose
+    region: content
   hide_description:
     type: boolean_checkbox
     weight: 14
     region: content
     settings:
       display_label: true
-    third_party_settings: { }
-  field_metatags:
-    weight: 26
-    settings:
-      sidebar: false
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   langcode:
     type: language_select
     weight: 0
@@ -186,7 +186,7 @@ content:
   latitude:
     type: readonly_field_widget
     region: content
-    weight: 17
+    weight: 18
     settings:
       label: above
       formatter_type: null
@@ -196,7 +196,7 @@ content:
   longitude:
     type: readonly_field_widget
     region: content
-    weight: 18
+    weight: 19
     settings:
       label: above
       formatter_type: null
@@ -257,7 +257,7 @@ content:
   provided_languages:
     type: readonly_field_widget
     region: content
-    weight: 29
+    weight: 26
     settings:
       label: above
       formatter_type: null
@@ -267,7 +267,7 @@ content:
   service_map_embed:
     type: readonly_field_widget
     region: content
-    weight: 20
+    weight: 21
     settings:
       label: above
       formatter_type: null
@@ -277,7 +277,7 @@ content:
   services:
     type: readonly_field_widget
     region: content
-    weight: 21
+    weight: 22
     settings:
       label: above
       formatter_type: null
@@ -287,7 +287,7 @@ content:
   streetview_entrance_url:
     type: readonly_field_widget
     region: content
-    weight: 19
+    weight: 20
     settings:
       label: above
       formatter_type: null

--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -162,6 +162,13 @@ content:
         duplicate: duplicate
     third_party_settings: {  }
     region: content
+  hide_description:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: { }
   field_metatags:
     weight: 26
     settings:

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
@@ -76,6 +76,7 @@ hidden:
   field_hs_emphasis: true
   field_lower_content: true
   field_metatags: true
+  hide_description: true
   langcode: true
   latitude: true
   longitude: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
@@ -77,6 +77,7 @@ hidden:
   field_hs_emphasis: true
   field_lower_content: true
   field_metatags: true
+  hide_description: true
   langcode: true
   latitude: true
   longitude: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
@@ -92,6 +92,7 @@ hidden:
   field_hs_emphasis: true
   field_lower_content: true
   field_metatags: true
+  hide_description: true
   langcode: true
   latitude: true
   longitude: true


### PR DESCRIPTION
…ld that was deleted by mistake

1. `make drush-cim && make drush-cr`
2. The previously hidden hide_description field should now be once again visible in the TPR unit page.