### PR TITLE
UHF-4052: Add announcement permissions for admin role

### DIFF
--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -8,6 +8,7 @@ dependencies:
     - media.type.image
     - media.type.remote_video
     - media.type.soundcloud
+    - node.type.announcement
     - node.type.landing_page
     - node.type.page
     - taxonomy.vocabulary.educational_mission
@@ -74,6 +75,7 @@ permissions:
   - 'administer users'
   - 'cancel account'
   - 'change own username'
+  - 'create announcement content'
   - 'create content translations'
   - 'create file media'
   - 'create hel_map media'
@@ -90,6 +92,8 @@ permissions:
   - 'create terms in keywords'
   - 'create url aliases'
   - 'delete all revisions'
+  - 'delete announcement revisions'
+  - 'delete any announcement content'
   - 'delete any file media'
   - 'delete any hel_map media'
   - 'delete any image media'
@@ -101,6 +105,7 @@ permissions:
   - 'delete content translations'
   - 'delete landing_page revisions'
   - 'delete media'
+  - 'delete own announcement content'
   - 'delete own file media'
   - 'delete own hel_map media'
   - 'delete own image media'
@@ -113,6 +118,7 @@ permissions:
   - 'delete terms in educational_mission'
   - 'delete terms in emphasis'
   - 'delete terms in keywords'
+  - 'edit any announcement content'
   - 'edit any file media'
   - 'edit any hel_map media'
   - 'edit any image media'
@@ -120,6 +126,7 @@ permissions:
   - 'edit any page content'
   - 'edit any remote_video media'
   - 'edit any soundcloud media'
+  - 'edit own announcement content'
   - 'edit own file media'
   - 'edit own hel_map media'
   - 'edit own image media'
@@ -135,9 +142,11 @@ permissions:
   - 'revert all revisions'
   - 'revert all tpr_service revisions'
   - 'revert all tpr_unit revisions'
+  - 'revert announcement revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
   - 'schedule publishing of nodes'
+  - 'translate announcement node'
   - 'translate any entity'
   - 'translate configuration'
   - 'translate editable entities'
@@ -169,6 +178,7 @@ permissions:
   - 'view all revisions'
   - 'view all tpr_service revisions'
   - 'view all tpr_unit revisions'
+  - 'view announcement revisions'
   - 'view any unpublished content'
   - 'view any unpublished content'
   - 'view any unpublished content'


### PR DESCRIPTION
How to test:

* Use Kasko development environment.
* Checkout this branch.
* Import configs: `drush cim`
* Check that the admin user is able to create, edit and delete announcements.