### PR TITLE
UHF-4127 Kasko front page and breadcrumb changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9126,12 +9126,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "4380afd33102db3cdc30abb30862305ad80f8c06"
+                "reference": "96043fa2417b37563e760d3a85e9863efe4d62b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/4380afd33102db3cdc30abb30862305ad80f8c06",
-                "reference": "4380afd33102db3cdc30abb30862305ad80f8c06",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/96043fa2417b37563e760d3a85e9863efe4d62b5",
+                "reference": "96043fa2417b37563e760d3a85e9863efe4d62b5",
                 "shasum": ""
             },
             "require": {
@@ -9187,7 +9187,7 @@
                 "issues": "https://github.com/ruflin/Elastica/issues",
                 "source": "https://github.com/ruflin/Elastica/tree/master"
             },
-            "time": "2022-01-18T14:53:15+00:00"
+            "time": "2022-01-25T11:53:47+00:00"
         },
         {
             "name": "stack/builder",

--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -1,12 +1,12 @@
 _core:
   default_config_hash: azWBxQFowXKyqUvvROIrMBXpwGaxz4JxhL6xz420P3Q
-applies_admin_routes: true
+applies_admin_routes: false
 include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
 include_home_segment: false
-alternative_title_field: field_breadcrumb_title
+alternative_title_field: ''
 home_segment_title: Home
 home_segment_keep: false
 include_title_segment: true
@@ -17,16 +17,16 @@ use_page_title_as_menu_title_fallback: false
 remove_repeated_segments: true
 language_path_prefix_as_segment: false
 absolute_paths: false
-hide_single_home_item: false
+hide_single_home_item: true
 term_hierarchy: false
 use_site_title: false
 add_structured_data_json_ld: false
-capitalizator_mode: ucwords
+capitalizator_mode: none
 capitalizator_ignored_words: {  }
 capitalizator_forced_words: {  }
 capitalizator_forced_words_case_sensitivity: true
 capitalizator_forced_words_first_letter: false
-follow_redirects: true
+follow_redirects: false
 limit_segment_display: false
 segment_display_limit: ''
 truncator_mode: false

--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -5,9 +5,9 @@ include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
-include_home_segment: false
+include_home_segment: true
 alternative_title_field: ''
-home_segment_title: Home
+home_segment_title: 'Childhood and education'
 home_segment_keep: false
 include_title_segment: true
 title_from_page_when_available: true

--- a/conf/cmi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/helfi_base_config.breadcrumb.yml
@@ -1,5 +1,5 @@
 langcode: en
 breadcrumb_base_links:
   -
-    text: ''
-    url: ''
+    text: Frontpage
+    url: 'https://www.hel.fi/helsinki/en'

--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -1,3 +1,5 @@
+langcode: en
+front_page_title: 'Childhood and education'
 asset_path: kasko-assets
 prefixes:
   en: childhood-and-education

--- a/conf/cmi/language/fi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/fi/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Etusivu
+home_segment_title: 'Kasvatus ja koulutus'

--- a/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
@@ -1,0 +1,4 @@
+breadcrumb_base_links:
+  -
+    text: Etusivu
+    url: 'https://www.hel.fi/helsinki/fi'

--- a/conf/cmi/language/fi/helfi_proxy.settings.yml
+++ b/conf/cmi/language/fi/helfi_proxy.settings.yml
@@ -1,0 +1,1 @@
+front_page_title: 'Kasvatus ja koulutus'

--- a/conf/cmi/language/sv/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/sv/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Hem
+home_segment_title: 'Fostran and utbildning'

--- a/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
@@ -1,0 +1,4 @@
+breadcrumb_base_links:
+  -
+    text: Framsida
+    url: 'https://www.hel.fi/helsinki/sv'

--- a/conf/cmi/language/sv/helfi_proxy.settings.yml
+++ b/conf/cmi/language/sv/helfi_proxy.settings.yml
@@ -1,0 +1,1 @@
+front_page_title: 'Fostran and utbildning'

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -2,13 +2,13 @@ _core:
   default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
 langcode: en
 uuid: fc91c53f-90ef-4ac1-b891-3f079c446d23
-name: 'Education Division'
+name: 'Childhood and education'
 mail: admin@example.com
 slogan: ''
 page:
   403: ''
   404: ''
-  front: /user/login
+  front: /front
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
How to test:

1. Set up your local with a dump from production.
2. Checkout this branch and run `make drush-cim && make drush-cr`
3. Now you front page should redirect to path '/front' which is empty unless you add a redirect to that path that takes you to the desired front page.
4. Make sure the breadcrumb has now the link to hel.fi as first link, the front page as second and the content you are on next etc..