### PR TITLE
UHF-4215: Link high school card to website link if one is provided an…

### DIFF
--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.high_school_card.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.high_school_card.yml
@@ -218,10 +218,10 @@ content:
     label: hidden
     settings:
       trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 13
     region: content

--- a/public/themes/custom/hdbt_subtheme/templates/content/tpr-unit.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/tpr-unit.html.twig
@@ -42,45 +42,47 @@
   %}
 
   <div{{ attributes.addClass(classes) }}>
-    {% if view_mode == 'high_school_card' and high_school_front_page_nid is not empty %}
+  {% if view_mode == 'high_school_card' and high_school_front_page_nid is not empty %}
     <a href="{{ url('entity.node.canonical', { 'node': high_school_front_page_nid }) }}" class="unit__link">
-      {% else %}
-      <a href="{{ url('entity.tpr_unit.canonical', { 'tpr_unit': entity.id() }) }}" class="unit__link">
+  {% elseif view_mode == 'high_school_card' and content.www is not empty %}
+    <a href="{{ content.www.0 }}" class="unit__link">
+  {% else %}
+    <a href="{{ url('entity.tpr_unit.canonical', { 'tpr_unit': entity.id() }) }}" class="unit__link">
+  {% endif %}
+      <div{{ image_attributes.addClass(picture_classes) }}>
+        {% if content.picture_url_override|render %}
+          {{ content.picture_url_override }}
+        {% elseif content.picture_url|render %}
+          {{ content.picture_url }}
+        {% else %}
+          {% include "@hdbt/misc/image-placeholder.twig" ignore missing %}
         {% endif %}
-        <div{{ image_attributes.addClass(picture_classes) }}>
-          {% if content.picture_url_override|render %}
-            {{ content.picture_url_override }}
-          {% elseif content.picture_url|render %}
-            {{ content.picture_url }}
-          {% else %}
-            {% include "@hdbt/misc/image-placeholder.twig" ignore missing %}
+      </div>
+      <div class="unit__text">
+        <div class="unit__text__content">
+          <h3 class="unit__title">
+            {% if high_school_front_page_title is not empty %}
+              {{ high_school_front_page_title }}
+            {% else %}
+              {{ entity.label }}
+            {% endif %}
+          </h3>
+          {% if content.address|render %}
+            <div class="unit__info-row unit__info-row--address">
+              {{ content.address }}
+            </div>
           {% endif %}
+          {% if content.description_summary|render %}
+            <div class="unit__short-desc">
+              {{ content.description_summary }}
+            </div>
+          {% endif %}
+          <span class="unit__arrow">
+          {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'arrow-right'} %}
+        </span>
         </div>
-        <div class="unit__text">
-          <div class="unit__text__content">
-            <h3 class="unit__title">
-              {% if high_school_front_page_title is not empty %}
-                {{ high_school_front_page_title }}
-              {% else %}
-                {{ entity.label }}
-              {% endif %}
-            </h3>
-            {% if content.address|render %}
-              <div class="unit__info-row unit__info-row--address">
-                {{ content.address }}
-              </div>
-            {% endif %}
-            {% if content.description_summary|render %}
-              <div class="unit__short-desc">
-                {{ content.description_summary }}
-              </div>
-            {% endif %}
-            <span class="unit__arrow">
-            {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'arrow-right'} %}
-          </span>
-          </div>
-        </div>
-      </a>
+      </div>
+    </a>
   </div>
 
 {% else %}


### PR DESCRIPTION
…d no high school front page is available

1. Checkout this branch on Kasko instance
2. `make drush-cim && make drush-cr`
3. Go to a page that has high school search or create one.
4. Make sure you have at least one high school listed that has high school frontpage set and one that has just the website link defined.
5. If you click on the one that has high school frontpage defined it should take you to that page, if you click on the card that has just website link defined it should take you to that page.