### PR TITLE
UHF-4212: Enable React & Share block for all pages

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
@@ -1,6 +1,6 @@
 uuid: f91ed535-c34c-4dbd-9c4e-178d68ff5d82
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_platform_config


### PR DESCRIPTION
How to test:

1. Checkout this branch
2. `make drush-cim && make drush-cr`
3. Edit your local.settings.php (create one if you don't have it) and add the React & Share API keys
`putenv('REACT_AND_SHARE_APIKEY_FI=gjhfvh3m4xcvnred');`
`putenv('REACT_AND_SHARE_APIKEY_SV=mwft0afec1l7d6g1');`
`putenv('REACT_AND_SHARE_APIKEY_EN=7zfblho0j7sm0url');`
4. Go to any part of the site and you should see the React & Share block there on the bottom of the page.