### PR TITLE
Add missing group permission for admins

### DIFF
--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -91,6 +91,7 @@ permissions:
   - 'assign read_only role'
   - 'assign school_editor role'
   - 'break content lock'
+  - 'bypass group access'
   - 'cancel account'
   - 'change own username'
   - 'create announcement content'


### PR DESCRIPTION
Adds "Bypass group access control" permission for admin users. Now the admins have permissions for all the groups.