### PR TITLE
UHF-X: Fixed typo on daycare search translations

### DIFF
--- a/conf/cmi/language/fi/views.view.daycare_search.yml
+++ b/conf/cmi/language/fi/views.view.daycare_search.yml
@@ -30,7 +30,7 @@ display:
             value: "<p>Tulokset järjestettynä hakemasi osoitteen perusteella. Etäisyys annettuun osoitteeseen on kerrottu toimipisteen osoitteen jälkeen tuloslistauksessa.</p>\r\n"
             format: minimal
           failed:
-            value: "<p>Voi harmi. Hakemaasi osoitetta ei löytynyt. Tarkista syöttämäsi osoite. Tulokset on nyt järjestetty aakkosjärjestyseen.</p>\r\n"
+            value: "<p>Voi harmi. Hakemaasi osoitetta ei löytynyt. Tarkista syöttämäsi osoite. Tulokset on nyt järjestetty aakkosjärjestykseen.</p>\r\n"
             format: minimal
       pager:
         options:


### PR DESCRIPTION
There was a typo. Now it is fixed.