### PR TITLE
UHF-X: Add check if the group news archive field is set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,9 @@ services:
       # To enable xdebug, run `export XDEBUG_ENABLE=true` before (re)starting your project.
       # Optionally, you can add this to your default environments variables to enable or disable
       # xdebug by default (like /etc/environments, ~/.bashrc, or ~/.zshrc).
-      XDEBUG_ENABLE: "${XDEBUG_ENABLE:-false}"
-      # DOCKERHOST: host.docker.internal
-      # Use drush server to run functional tests so we don't have to care about
-      # permission issues.
+      XDEBUG_ENABLE: "true"
+      XDEBUG_CONFIG: "remote_port=9001 remote_host=host.docker.internal remote_connect_back=0"
+      PHP_IDE_CONFIG: "serverName=${DRUPAL_HOSTNAME}"
       SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
       SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
       BROWSERTEST_OUTPUT_BASE_URL: "https://${DRUPAL_HOSTNAME}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,10 @@ services:
       # To enable xdebug, run `export XDEBUG_ENABLE=true` before (re)starting your project.
       # Optionally, you can add this to your default environments variables to enable or disable
       # xdebug by default (like /etc/environments, ~/.bashrc, or ~/.zshrc).
-      XDEBUG_ENABLE: "true"
-      XDEBUG_CONFIG: "remote_port=9001 remote_host=host.docker.internal remote_connect_back=0"
-      PHP_IDE_CONFIG: "serverName=${DRUPAL_HOSTNAME}"
+      XDEBUG_ENABLE: "${XDEBUG_ENABLE:-false}"
+      # DOCKERHOST: host.docker.internal
+      # Use drush server to run functional tests so we don't have to care about
+      # permission issues.
       SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
       SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
       BROWSERTEST_OUTPUT_BASE_URL: "https://${DRUPAL_HOSTNAME}"

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -112,6 +112,10 @@ function hdbt_subtheme_preprocess_paragraph(array &$variables) {
     $paragraph->hasField('field_group_news_archive')
   ) {
     $field_content_id = $paragraph->get('field_group_news_archive')->getString();
+    // Check if the field has value.
+    if (empty($field_content_id)) {
+      return;
+    }
     $node = Node::load($field_content_id);
     $variables['group_news_archive_location'] = !$node->isNew() ? $node->toUrl('canonical') : NULL;
   }

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--group-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--group-news.html.twig
@@ -15,19 +15,21 @@
         {{ drupal_view('latest_group_news', 'latest_group_news_4', group_id) }}
       {% endif %}
 
-      <div class="group-news__links">
-        {% set link_title %}
-          {{ 'All news'|t({}, {'context': 'Group news archive link'}) }}
-        {% endset %}
-        {% set link_attributes = {
-          'class': [
-            'group-news__archive-link',
-            'hds-button',
-            'hds-button--supplementary',
-          ],
-        } %}
-        {{ link(link_title, group_news_archive_location, link_attributes) }}
-      </div>
+      {% if group_news_archive_location %}
+        <div class="group-news__links">
+          {% set link_title %}
+            {{ 'All news'|t({}, {'context': 'Group news archive link'}) }}
+          {% endset %}
+          {% set link_attributes = {
+            'class': [
+              'group-news__archive-link',
+              'hds-button',
+              'hds-button--supplementary',
+            ],
+          } %}
+          {{ link(link_title, group_news_archive_location, link_attributes) }}
+        </div>
+      {% endif %}
 
     {% endblock component_content %}
   {% endembed %}


### PR DESCRIPTION
How to test:

1. Take latest db dump from KASKO testing
2. `make drush-cr`
3.  Try going to https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/helsingin-kuvataidelukio/kuvataidelukion-aliperussivu and it should work. It used to give WSOD.
4. Go edit the page and add Teron testi uutisarkisto as the group news archive page on one of the paragraphs. This should also work now.