### PR TITLE
UHF-X: Fix group menu cache issue by patching the module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,9 @@
                 "https://www.drupal.org/project/group/issues/2842630": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch",
                 "https://www.drupal.org/project/group/issues/2815971": "https://www.drupal.org/files/issues/2021-02-19/2815971-28.patch",
                 "https://www.drupal.org/project/group/issues/3210808": "https://www.drupal.org/files/issues/2021-04-26/uasort-comparison-3210808-2.patch"
+            },
+            "drupal/group_content_menu": {
+                "https://www.drupal.org/project/group_content_menu/issues/3209011": "https://www.drupal.org/files/issues/2021-04-21/group_content_menu-active_trail_cache_problem-3209011-10.patch"
             }
         }
     },


### PR DESCRIPTION
1. Checkout this branch.
2. `composer install`
3. Make sure you have caches on on your local and go to check the group menu that the active trail changes as you change the page.