### PR TITLE
UHF-5573: Change news item teaser image to 3:2 aspect ratio

### DIFF
--- a/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
@@ -26,7 +26,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: media_library
+      view_mode: image
       link: false
     third_party_settings: {  }
     weight: 1


### PR DESCRIPTION
How to test:

1. Checkout latest dev.
2. Get latest database from testing and run `make fresh`
3. Checkout this branch and run `make drush-cr && make drush-cim`
4. Go to https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/helsingin-kuvataidelukio/teron-testi-uutisarkisto and make sure the news items listed there use 3:2 aspect ratio style. See the screenshot as example.
5. Check also these PRs:
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/318
https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/27

<img width="1916" alt="Screenshot 2022-05-09 at 16 28 38" src="https://user-images.githubusercontent.com/2276077/167420566-ee53ca84-4f1c-471e-84c0-923ec2753c54.png">