### PR TITLE
UHF-6838: KASKO Elasticsearch

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+
+services:
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0
+    container_name: "${COMPOSE_PROJECT_NAME}-elastic"
+    environment:
+      - node.name="${COMPOSE_PROJECT_NAME}-elastic"
+      - discovery.seed_hosts=elastic
+      - cluster.name=es-docker-cluster
+      - cluster.initial_master_nodes="${COMPOSE_PROJECT_NAME}-elastic"
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "http.cors.allow-origin=\"*\""
+      - "http.cors.enabled=true"
+      - "http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+      - "http.cors.allow-credentials=true"
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200-9220:9200
+    networks:
+      - internal
+      - stonehenge-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.entrypoints=https"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.rule=Host(`elastic-${DRUPAL_HOSTNAME}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.tls=true"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-elastic.loadbalancer.server.port=9200"
+      - "traefik.docker.network=stonehenge-network"
+      - "traefik.port=9200"


### PR DESCRIPTION
## What was done
Added `docker-compose.override.yml` with config for Elasticsearch container

## How to install
1. Set up KASKO instance
2. Checkout this branch: `UHF-6838_kasko_elastic`
3. Run `make up` to just spin up the containers

## How to test
1. Run `make ps` to list the running containers
2. Make note of the port of the `helfi-kasko-elastic` container (e.g. 9209)
3. Access http://localhost:9209/ with browser to see that Elasticsearch is up and running

