### PR TITLE
UHF-7450: Added custom access check when adding media to new news ite…

### DIFF
--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -14,9 +14,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\group\Entity\Group;
 use Drupal\helfi_group\UnitFormAlter;
-use Drupal\media_library\MediaLibraryState;
 
 /**
  * Implements hook_preprocess_HOOK().

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -7,13 +7,16 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\Group;
 use Drupal\helfi_group\UnitFormAlter;
+use Drupal\media_library\MediaLibraryState;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -128,4 +131,27 @@ function helfi_group_menu_local_tasks_alter(&$data, $route_name): void {
   if (in_array($route_name, $routes)) {
     unset($data['tabs'][0][$local_task]);
   }
+}
+
+/**
+ * Implements hook_entity_create_access().
+ *
+ * For unknown reason the route for adding media as a value to a field
+ * is null when using media library on news item main image with school editor
+ * role. This hook will allow access to school editors to add the media
+ * references when creating new news item content.
+ *
+ * @see Drupal\media_library\MediaLibraryFieldWidgetOpener()
+ */
+function helfi_group_node_create_access(AccountInterface $account, array $context, $entity_bundle) {
+  if (!empty(\Drupal::routeMatch()->getRouteName())) {
+    return AccessResult::neutral();
+  }
+
+  return (
+    $entity_bundle === 'news_item' &&
+    in_array('school_editor', $account->getRoles())
+  )
+    ? AccessResult::allowed()
+    : AccessResult::neutral();
 }


### PR DESCRIPTION
…m content as school editor

# [UHF-7450](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7450)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout UHF-7450_main_image_add_bug_with_school_editor`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as a school editor that is attached to a group.
* [ ] Add news item under the group and while on the node add form try to add a main image for the news item. ATTENTION! The adding was broken only when creating a new news item - not when editing already created items. 
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
