### PR TITLE
UHF-6317: Add unit categories and separate unit roles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
             "@lint-php",
             "@test-php"
         ],
-        "test-php": "vendor/bin/phpunit -c phpunit.xml.dist",
+        "test-php": "vendor/bin/phpunit -c $PWD/phpunit.xml.dist",
         "lint-php": "vendor/bin/phpcs --standard=Drupal",
         "copy-commit-message-script": "make copy-commit-message-script",
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4650,16 +4650,16 @@
         },
         {
             "name": "drupal/helfi_tpr",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr.git",
-                "reference": "5ed2a62fb51909446690421c0a89bcee38576b63"
+                "reference": "df201f00eb455d6f6a5f22c573290b272c395043"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/5ed2a62fb51909446690421c0a89bcee38576b63",
-                "reference": "5ed2a62fb51909446690421c0a89bcee38576b63",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/df201f00eb455d6f6a5f22c573290b272c395043",
+                "reference": "df201f00eb455d6f6a5f22c573290b272c395043",
                 "shasum": ""
             },
             "require": {
@@ -4684,10 +4684,10 @@
             ],
             "description": "TPR integration",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/2.1.3",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/2.1.4",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/issues"
             },
-            "time": "2022-10-27T05:58:29+00:00"
+            "time": "2022-11-23T09:13:30+00:00"
         },
         {
             "name": "drupal/helfi_tunnistamo",
@@ -17189,5 +17189,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
@@ -103,6 +104,16 @@ content:
       label: above
       formatter_type: null
       formatter_settings: null
+      show_description: false
+    third_party_settings: {  }
+  field_categories:
+    type: readonly_field_widget
+    weight: 39
+    region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
   field_content:

--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -251,16 +251,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  ontologyword_ids:
-    type: readonly_field_widget
-    weight: 35
-    region: content
-    settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
-      show_description: false
-    third_party_settings: {  }
   path:
     type: path
     weight: 13
@@ -363,3 +353,4 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  ontologyword_ids: true

--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -47,7 +47,7 @@ content:
     third_party_settings: {  }
   accessibility_www:
     type: readonly_field_widget
-    weight: 13
+    weight: 14
     region: content
     settings:
       label: above
@@ -57,7 +57,7 @@ content:
     third_party_settings: {  }
   address:
     type: readonly_field_widget
-    weight: 16
+    weight: 17
     region: content
     settings:
       label: above
@@ -67,7 +67,7 @@ content:
     third_party_settings: {  }
   address_postal:
     type: readonly_field_widget
-    weight: 18
+    weight: 19
     region: content
     settings:
       label: above
@@ -77,7 +77,7 @@ content:
     third_party_settings: {  }
   call_charge_info:
     type: readonly_field_widget
-    weight: 17
+    weight: 18
     region: content
     settings:
       label: above
@@ -87,7 +87,7 @@ content:
     third_party_settings: {  }
   description:
     type: readonly_field_widget
-    weight: 14
+    weight: 15
     region: content
     settings:
       label: above
@@ -107,7 +107,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 25
+    weight: 26
     region: content
     settings:
       title: Paragraph
@@ -126,7 +126,7 @@ content:
     third_party_settings: {  }
   field_hs_front_page:
     type: entity_reference_autocomplete
-    weight: 28
+    weight: 29
     region: content
     settings:
       match_operator: CONTAINS
@@ -136,7 +136,7 @@ content:
     third_party_settings: {  }
   field_lower_content:
     type: paragraphs
-    weight: 26
+    weight: 27
     region: content
     settings:
       title: Paragraph
@@ -155,7 +155,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 24
+    weight: 25
     region: content
     settings:
       sidebar: false
@@ -163,7 +163,7 @@ content:
     third_party_settings: {  }
   field_study_field:
     type: select2_entity_reference
-    weight: 30
+    weight: 31
     region: content
     settings:
       width: 100%
@@ -173,7 +173,7 @@ content:
     third_party_settings: {  }
   field_unit_type:
     type: entity_reference_autocomplete
-    weight: 29
+    weight: 30
     region: content
     settings:
       match_operator: CONTAINS
@@ -183,14 +183,14 @@ content:
     third_party_settings: {  }
   hide_description:
     type: boolean_checkbox
-    weight: 15
+    weight: 16
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   hide_sidebar_navigation:
     type: boolean_checkbox
-    weight: 31
+    weight: 32
     region: content
     settings:
       display_label: true
@@ -204,7 +204,7 @@ content:
     third_party_settings: {  }
   latitude:
     type: readonly_field_widget
-    weight: 19
+    weight: 20
     region: content
     settings:
       label: above
@@ -214,7 +214,7 @@ content:
     third_party_settings: {  }
   longitude:
     type: readonly_field_widget
-    weight: 20
+    weight: 21
     region: content
     settings:
       label: above
@@ -240,9 +240,19 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  ontologyword_ids:
+    type: readonly_field_widget
+    weight: 35
+    region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -275,7 +285,7 @@ content:
     third_party_settings: {  }
   provided_languages:
     type: readonly_field_widget
-    weight: 27
+    weight: 28
     region: content
     settings:
       label: above
@@ -285,7 +295,7 @@ content:
     third_party_settings: {  }
   service_map_embed:
     type: readonly_field_widget
-    weight: 22
+    weight: 23
     region: content
     settings:
       label: above
@@ -295,7 +305,7 @@ content:
     third_party_settings: {  }
   services:
     type: readonly_field_widget
-    weight: 23
+    weight: 24
     region: content
     settings:
       label: above
@@ -305,19 +315,19 @@ content:
     third_party_settings: {  }
   show_www:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   streetview_entrance_url:
     type: readonly_field_widget
-    weight: 21
+    weight: 22
     region: content
     settings:
       label: above

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -3,15 +3,18 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
     - entity_reference_revisions
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
     - link
@@ -203,6 +206,7 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
   field_hs_front_page: true
   field_study_field: true
   field_unit_type: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.high_school_card.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.high_school_card.yml
@@ -4,15 +4,18 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.high_school_card
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
     - entity_reference_revisions
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
     - link
@@ -211,6 +214,7 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
   field_study_field: true
   field_unit_type: true
   hide_description: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.minimal
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
@@ -12,6 +13,7 @@ dependencies:
     - field.field.tpr_unit.tpr_unit.field_unit_type
   module:
     - address
+    - helfi_address_search
     - helfi_tpr
 _core:
   default_config_hash: 2R6fCnxqAEIItVBo_RZsOmxxfH1h7s4rGXJrZ7U3pTM
@@ -53,6 +55,7 @@ hidden:
   created: true
   description: true
   email: true
+  field_categories: true
   field_content: true
   field_hs_front_page: true
   field_lower_content: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
@@ -4,14 +4,17 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.teaser
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
 _core:
@@ -72,6 +75,7 @@ hidden:
   created: true
   description: true
   email: true
+  field_categories: true
   field_content: true
   field_hs_front_page: true
   field_lower_content: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
@@ -4,14 +4,17 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.teaser_with_image
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
     - telephone
@@ -73,6 +76,7 @@ hidden:
   created: true
   description: true
   email: true
+  field_categories: true
   field_content: true
   field_hs_front_page: true
   field_lower_content: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.vocational_school_card.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.vocational_school_card.yml
@@ -4,15 +4,18 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.vocational_school_card
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
     - entity_reference_revisions
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
     - link
@@ -204,6 +207,7 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
   field_hs_front_page: true
   field_study_field: true
   field_unit_type: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
@@ -4,14 +4,17 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.wide_teaser
+    - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
     - field.field.tpr_unit.tpr_unit.field_study_field
     - field.field.tpr_unit.tpr_unit.field_unit_type
+    - responsive_image.styles.image__3_2
   module:
     - address
+    - helfi_address_search
     - helfi_tpr
     - imagecache_external
     - telephone
@@ -88,6 +91,7 @@ hidden:
   created: true
   description: true
   email: true
+  field_categories: true
   field_content: true
   field_hs_front_page: true
   field_lower_content: true

--- a/conf/cmi/field.field.tpr_unit.tpr_unit.field_categories.yml
+++ b/conf/cmi/field.field.tpr_unit.tpr_unit.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: b1e61bbf-6cb3-4451-acbc-624950250aeb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.tpr_unit.field_categories
+  module:
+    - helfi_tpr
+id: tpr_unit.tpr_unit.field_categories
+field_name: field_categories
+entity_type: tpr_unit
+bundle: tpr_unit
+label: Categories
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.tpr_unit.tpr_unit.field_categories.yml
+++ b/conf/cmi/field.field.tpr_unit.tpr_unit.field_categories.yml
@@ -13,7 +13,7 @@ bundle: tpr_unit
 label: Categories
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.storage.tpr_unit.field_categories.yml
+++ b/conf/cmi/field.storage.tpr_unit.field_categories.yml
@@ -1,0 +1,21 @@
+uuid: 2d249722-1a7d-4556-bf8f-de32502b6163
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_unit.field_categories
+field_name: field_categories
+entity_type: tpr_unit
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/group.role.upper_secondary_school-161bb35a9.yml
+++ b/conf/cmi/group.role.upper_secondary_school-161bb35a9.yml
@@ -8,7 +8,7 @@ dependencies:
     config:
       - user.role.school_editor
 id: upper_secondary_school-161bb35a9
-label: 'School editor'
+label: 'Upper secondary school editor'
 weight: 5
 internal: true
 audience: outsider

--- a/conf/cmi/group.role.upper_secondary_school-2e5f4db8d.yml
+++ b/conf/cmi/group.role.upper_secondary_school-2e5f4db8d.yml
@@ -1,0 +1,17 @@
+uuid: 4569e698-e7d4-44db-83bc-332f4dcbda0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.upper_secondary_school
+  enforced:
+    config:
+      - user.role.comprehensive_school_editor
+id: upper_secondary_school-2e5f4db8d
+label: 'Comprehensive school editor'
+weight: 7
+internal: true
+audience: outsider
+group_type: upper_secondary_school
+permissions_ui: false
+permissions: {  }

--- a/conf/cmi/group.role.upper_secondary_school-6ebf7ed4b.yml
+++ b/conf/cmi/group.role.upper_secondary_school-6ebf7ed4b.yml
@@ -1,0 +1,17 @@
+uuid: d4338516-7887-4796-b569-ed46a17167f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.upper_secondary_school
+  enforced:
+    config:
+      - user.role.playground_editor
+id: upper_secondary_school-6ebf7ed4b
+label: 'Playground editor'
+weight: 6
+internal: true
+audience: outsider
+group_type: upper_secondary_school
+permissions_ui: false
+permissions: {  }

--- a/conf/cmi/group.role.upper_secondary_school-ed6e8ed69.yml
+++ b/conf/cmi/group.role.upper_secondary_school-ed6e8ed69.yml
@@ -1,0 +1,17 @@
+uuid: 37709d9c-5b3d-4b76-b32c-28ec480560a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.upper_secondary_school
+  enforced:
+    config:
+      - user.role.daycare_editor
+id: upper_secondary_school-ed6e8ed69
+label: 'Daycare editor'
+weight: 8
+internal: true
+audience: outsider
+group_type: upper_secondary_school
+permissions_ui: false
+permissions: {  }

--- a/conf/cmi/language/fi/field.field.tpr_unit.tpr_unit.field_categories.yml
+++ b/conf/cmi/language/fi/field.field.tpr_unit.tpr_unit.field_categories.yml
@@ -1,0 +1,1 @@
+label: Kategoriat

--- a/conf/cmi/language/fi/user.role.comprehensive_school_editor.yml
+++ b/conf/cmi/language/fi/user.role.comprehensive_school_editor.yml
@@ -1,0 +1,1 @@
+label: 'Peruskoulujen sisällöntuottaja'

--- a/conf/cmi/language/fi/user.role.daycare_editor.yml
+++ b/conf/cmi/language/fi/user.role.daycare_editor.yml
@@ -1,0 +1,1 @@
+label: 'Päiväkotien sisällöntuottaja'

--- a/conf/cmi/language/fi/user.role.playground_editor.yml
+++ b/conf/cmi/language/fi/user.role.playground_editor.yml
@@ -1,0 +1,1 @@
+label: 'Leikkipuistojen sisällöntuottaja'

--- a/conf/cmi/language/fi/user.role.school_editor.yml
+++ b/conf/cmi/language/fi/user.role.school_editor.yml
@@ -1,1 +1,1 @@
-label: 'Koulujen sisällöntuottaja'
+label: 'Lukioiden sisällöntuottaja'

--- a/conf/cmi/system.action.user_add_role_action.comprehensive_school_editor.yml
+++ b/conf/cmi/system.action.user_add_role_action.comprehensive_school_editor.yml
@@ -1,0 +1,14 @@
+uuid: c23cd6b5-1fde-40a8-aeec-96c914e8ff87
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.comprehensive_school_editor
+  module:
+    - user
+id: user_add_role_action.comprehensive_school_editor
+label: 'Add the Comprehensive school editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: comprehensive_school_editor

--- a/conf/cmi/system.action.user_add_role_action.daycare_editor.yml
+++ b/conf/cmi/system.action.user_add_role_action.daycare_editor.yml
@@ -1,0 +1,14 @@
+uuid: 7b12bbff-0fab-43dc-b30c-d918712367ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.daycare_editor
+  module:
+    - user
+id: user_add_role_action.daycare_editor
+label: 'Add the Daycare editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: daycare_editor

--- a/conf/cmi/system.action.user_add_role_action.playground_editor.yml
+++ b/conf/cmi/system.action.user_add_role_action.playground_editor.yml
@@ -1,0 +1,14 @@
+uuid: 1371d4cb-d0fe-4b57-bf0b-13af408e766e
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.playground_editor
+  module:
+    - user
+id: user_add_role_action.playground_editor
+label: 'Add the Playground editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: playground_editor

--- a/conf/cmi/system.action.user_remove_role_action.comprehensive_school_editor.yml
+++ b/conf/cmi/system.action.user_remove_role_action.comprehensive_school_editor.yml
@@ -1,0 +1,14 @@
+uuid: a204632b-efcc-4111-83e5-4ea7dcfedef4
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.comprehensive_school_editor
+  module:
+    - user
+id: user_remove_role_action.comprehensive_school_editor
+label: 'Remove the Comprehensive school editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: comprehensive_school_editor

--- a/conf/cmi/system.action.user_remove_role_action.daycare_editor.yml
+++ b/conf/cmi/system.action.user_remove_role_action.daycare_editor.yml
@@ -1,0 +1,14 @@
+uuid: cd18d030-3ab5-4c3d-a24a-2ea0916e6709
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.daycare_editor
+  module:
+    - user
+id: user_remove_role_action.daycare_editor
+label: 'Remove the Daycare editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: daycare_editor

--- a/conf/cmi/system.action.user_remove_role_action.playground_editor.yml
+++ b/conf/cmi/system.action.user_remove_role_action.playground_editor.yml
@@ -1,0 +1,14 @@
+uuid: 5e77b2f7-1fa5-4a3d-b40b-9e7f3011cb1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.playground_editor
+  module:
+    - user
+id: user_remove_role_action.playground_editor
+label: 'Remove the Playground editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: playground_editor

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -55,7 +55,7 @@ _core:
   default_config_hash: 7RTyCpgMKCMdwkxYrpzYOCq7DQDHO0SrTjB7xwFaIyI
 id: admin
 label: Administrator
-weight: 5
+weight: -1
 is_admin: null
 permissions:
   - 'access administration pages'

--- a/conf/cmi/user.role.comprehensive_school_editor.yml
+++ b/conf/cmi/user.role.comprehensive_school_editor.yml
@@ -1,0 +1,9 @@
+uuid: 99604164-cb8c-4edb-b76e-bfa36fd13fbc
+langcode: en
+status: true
+dependencies: {  }
+id: comprehensive_school_editor
+label: 'Comprehensive school editor'
+weight: 7
+is_admin: null
+permissions: {  }

--- a/conf/cmi/user.role.comprehensive_school_editor.yml
+++ b/conf/cmi/user.role.comprehensive_school_editor.yml
@@ -1,9 +1,70 @@
 uuid: 99604164-cb8c-4edb-b76e-bfa36fd13fbc
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.full_html
+    - filter.format.minimal
+    - media.type.file
+    - media.type.hel_map
+    - media.type.helfi_chart
+    - media.type.image
+    - media.type.remote_video
+    - media.type.soundcloud
+  module:
+    - content_translation
+    - editoria11y
+    - file
+    - filter
+    - helfi_api_base
+    - helfi_tpr
+    - media
+    - node
+    - scheduler
+    - system
 id: comprehensive_school_editor
 label: 'Comprehensive school editor'
-weight: 7
+weight: -5
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access content overview'
+  - 'access files overview'
+  - 'access media overview'
+  - 'access remote entities overview'
+  - 'access tpr_service overview'
+  - 'access tpr_unit overview'
+  - 'access user profiles'
+  - 'admin comprehensive school units'
+  - 'cancel account'
+  - 'change own username'
+  - 'create file media'
+  - 'create hel_map media'
+  - 'create helfi_chart media'
+  - 'create image media'
+  - 'create media'
+  - 'create remote_video media'
+  - 'create soundcloud media'
+  - 'delete media'
+  - 'delete own file media'
+  - 'delete own hel_map media'
+  - 'delete own helfi_chart media'
+  - 'delete own image media'
+  - 'delete own remote_video media'
+  - 'delete own soundcloud media'
+  - 'edit own file media'
+  - 'edit own hel_map media'
+  - 'edit own helfi_chart media'
+  - 'edit own image media'
+  - 'edit own remote_video media'
+  - 'edit own soundcloud media'
+  - 'schedule publishing of nodes'
+  - 'translate editable entities'
+  - 'update media'
+  - 'use text format full_html'
+  - 'use text format minimal'
+  - 'view all media revisions'
+  - 'view editoria11y checker'
+  - 'view own unpublished content'
+  - 'view own unpublished media'
+  - 'view the administration theme'
+  - 'view unpublished tpr_unit'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -38,7 +38,7 @@ _core:
   default_config_hash: EVzxFtbOrGVTXWw2GTh1fEzzqruPEqSo84k10-BF6eA
 id: content_producer
 label: 'Content producer'
-weight: -7
+weight: -3
 is_admin: null
 permissions:
   - 'access content overview'

--- a/conf/cmi/user.role.daycare_editor.yml
+++ b/conf/cmi/user.role.daycare_editor.yml
@@ -1,0 +1,9 @@
+uuid: d3b2a2be-12d1-444f-a290-ab07f3548415
+langcode: en
+status: true
+dependencies: {  }
+id: daycare_editor
+label: 'Daycare editor'
+weight: 8
+is_admin: null
+permissions: {  }

--- a/conf/cmi/user.role.daycare_editor.yml
+++ b/conf/cmi/user.role.daycare_editor.yml
@@ -1,9 +1,70 @@
 uuid: d3b2a2be-12d1-444f-a290-ab07f3548415
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.full_html
+    - filter.format.minimal
+    - media.type.file
+    - media.type.hel_map
+    - media.type.helfi_chart
+    - media.type.image
+    - media.type.remote_video
+    - media.type.soundcloud
+  module:
+    - content_translation
+    - editoria11y
+    - file
+    - filter
+    - helfi_api_base
+    - helfi_tpr
+    - media
+    - node
+    - scheduler
+    - system
 id: daycare_editor
 label: 'Daycare editor'
-weight: 8
+weight: -7
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access content overview'
+  - 'access files overview'
+  - 'access media overview'
+  - 'access remote entities overview'
+  - 'access tpr_service overview'
+  - 'access tpr_unit overview'
+  - 'access user profiles'
+  - 'admin daycare units'
+  - 'cancel account'
+  - 'change own username'
+  - 'create file media'
+  - 'create hel_map media'
+  - 'create helfi_chart media'
+  - 'create image media'
+  - 'create media'
+  - 'create remote_video media'
+  - 'create soundcloud media'
+  - 'delete media'
+  - 'delete own file media'
+  - 'delete own hel_map media'
+  - 'delete own helfi_chart media'
+  - 'delete own image media'
+  - 'delete own remote_video media'
+  - 'delete own soundcloud media'
+  - 'edit own file media'
+  - 'edit own hel_map media'
+  - 'edit own helfi_chart media'
+  - 'edit own image media'
+  - 'edit own remote_video media'
+  - 'edit own soundcloud media'
+  - 'schedule publishing of nodes'
+  - 'translate editable entities'
+  - 'update media'
+  - 'use text format full_html'
+  - 'use text format minimal'
+  - 'view all media revisions'
+  - 'view editoria11y checker'
+  - 'view own unpublished content'
+  - 'view own unpublished media'
+  - 'view the administration theme'
+  - 'view unpublished tpr_unit'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -42,7 +42,7 @@ dependencies:
     - view_unpublished
 id: editor
 label: Editor
-weight: 4
+weight: -2
 is_admin: null
 permissions:
   - 'access administration pages'

--- a/conf/cmi/user.role.playground_editor.yml
+++ b/conf/cmi/user.role.playground_editor.yml
@@ -1,9 +1,70 @@
 uuid: 0dd1314a-c73f-4e8a-bd38-f64530063132
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.full_html
+    - filter.format.minimal
+    - media.type.file
+    - media.type.hel_map
+    - media.type.helfi_chart
+    - media.type.image
+    - media.type.remote_video
+    - media.type.soundcloud
+  module:
+    - content_translation
+    - editoria11y
+    - file
+    - filter
+    - helfi_api_base
+    - helfi_tpr
+    - media
+    - node
+    - scheduler
+    - system
 id: playground_editor
 label: 'Playground editor'
-weight: 6
+weight: -6
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access content overview'
+  - 'access files overview'
+  - 'access media overview'
+  - 'access remote entities overview'
+  - 'access tpr_service overview'
+  - 'access tpr_unit overview'
+  - 'access user profiles'
+  - 'admin playground units'
+  - 'cancel account'
+  - 'change own username'
+  - 'create file media'
+  - 'create hel_map media'
+  - 'create helfi_chart media'
+  - 'create image media'
+  - 'create media'
+  - 'create remote_video media'
+  - 'create soundcloud media'
+  - 'delete media'
+  - 'delete own file media'
+  - 'delete own hel_map media'
+  - 'delete own helfi_chart media'
+  - 'delete own image media'
+  - 'delete own remote_video media'
+  - 'delete own soundcloud media'
+  - 'edit own file media'
+  - 'edit own hel_map media'
+  - 'edit own helfi_chart media'
+  - 'edit own image media'
+  - 'edit own remote_video media'
+  - 'edit own soundcloud media'
+  - 'schedule publishing of nodes'
+  - 'translate editable entities'
+  - 'update media'
+  - 'use text format full_html'
+  - 'use text format minimal'
+  - 'view all media revisions'
+  - 'view editoria11y checker'
+  - 'view own unpublished content'
+  - 'view own unpublished media'
+  - 'view the administration theme'
+  - 'view unpublished tpr_unit'

--- a/conf/cmi/user.role.playground_editor.yml
+++ b/conf/cmi/user.role.playground_editor.yml
@@ -1,0 +1,9 @@
+uuid: 0dd1314a-c73f-4e8a-bd38-f64530063132
+langcode: en
+status: true
+dependencies: {  }
+id: playground_editor
+label: 'Playground editor'
+weight: 6
+is_admin: null
+permissions: {  }

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -9,7 +9,7 @@ dependencies:
     - view_unpublished
 id: read_only
 label: 'Read only'
-weight: 2
+weight: -8
 is_admin: null
 permissions:
   - 'access toolbar'

--- a/conf/cmi/user.role.school_editor.yml
+++ b/conf/cmi/user.role.school_editor.yml
@@ -27,7 +27,7 @@ dependencies:
     - toolbar
 id: school_editor
 label: 'Upper secondary school editor'
-weight: -6
+weight: -4
 is_admin: null
 permissions:
   - 'access content overview'

--- a/conf/cmi/user.role.school_editor.yml
+++ b/conf/cmi/user.role.school_editor.yml
@@ -21,13 +21,12 @@ dependencies:
     - helfi_tpr
     - media
     - node
-    - override_node_options
     - publication_date
     - scheduler
     - system
     - toolbar
 id: school_editor
-label: 'School editor'
+label: 'Upper secondary school editor'
 weight: -6
 is_admin: null
 permissions:

--- a/public/modules/custom/helfi_kasko_content/config/install/field.field.tpr_unit.tpr_unit.field_categories.yml
+++ b/public/modules/custom/helfi_kasko_content/config/install/field.field.tpr_unit.tpr_unit.field_categories.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.tpr_unit.field_categories
+  module:
+    - helfi_tpr
+id: tpr_unit.tpr_unit.field_categories
+field_name: field_categories
+entity_type: tpr_unit
+bundle: tpr_unit
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/helfi_kasko_content/config/install/field.storage.tpr_unit.field_categories.yml
+++ b/public/modules/custom/helfi_kasko_content/config/install/field.storage.tpr_unit.field_categories.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_unit.field_categories
+field_name: field_categories
+entity_type: tpr_unit
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - drupal:content_translation
   - drupal:language
   - drupal:taxonomy
+  - helfi_tpr:helfi_tpr

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
@@ -3,3 +3,7 @@ type: module
 description: 'Performs alterations to content.'
 core: 8.x
 core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:content_translation
+  - drupal:language
+  - drupal:taxonomy

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\helfi_tpr\UnitCategoryUtility;
+use Drupal\helfi_kasko_content\UnitCategoryUtility;
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -18,8 +18,13 @@ use Drupal\helfi_tpr\UnitCategoryUtility;
 function helfi_kasko_content_tpr_unit_access(EntityInterface $entity, $operation, AccountInterface $account) : AccessResult {
   /** @var \Drupal\helfi_tpr\Entity\Unit $entity */
   // Allow users with special permissions to update specific TPR units.
-  if ($operation === 'update') {
-    $unit_categories = $entity->getCategories();
+  if ($operation === 'update' && $entity->hasField('field_categories')) {
+    $unit_categories = [];
+    foreach ($entity->get('field_categories')->getValue() as $value) {
+      if (!empty($value['value'])) {
+        $unit_categories[] = $value['value'];
+      }
+    }
 
     if (in_array(UnitCategoryUtility::DAYCARE, $unit_categories)) {
       return AccessResult::allowedIfHasPermission($account, 'admin daycare units');

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -5,8 +5,37 @@
  * Contains alterations for content.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\helfi_tpr\UnitCategoryUtility;
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function helfi_kasko_content_tpr_unit_access(EntityInterface $entity, $operation, AccountInterface $account) : AccessResult {
+  /** @var \Drupal\helfi_tpr\Entity\Unit $entity */
+  // Allow users with special permissions to update specific TPR units.
+  if ($operation === 'update') {
+    $unit_categories = $entity->getCategories();
+
+    if (in_array(UnitCategoryUtility::DAYCARE, $unit_categories)) {
+      return AccessResult::allowedIfHasPermission($account, 'admin daycare units');
+    }
+
+    if (in_array(UnitCategoryUtility::COMPREHENSIVE_SCHOOL, $unit_categories)) {
+      return AccessResult::allowedIfHasPermission($account, 'admin comprehensive school units');
+    }
+
+    if (in_array(UnitCategoryUtility::PLAYGROUND, $unit_categories)) {
+      return AccessResult::allowedIfHasPermission($account, 'admin playground units');
+    }
+  }
+
+  return AccessResult::neutral();
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.permissions.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.permissions.yml
@@ -1,0 +1,6 @@
+'admin daycare units':
+  title: 'Administer daycare TPR units'
+'admin comprehensive school units':
+  title: 'Administer comprehensive school TPR units'
+'admin playground units':
+  title: 'Administer playground TPR units'

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
@@ -1,5 +1,4 @@
 services:
   Drupal\helfi_kasko_content\EventSubscriber\UnitCategorySubscriber:
-    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: 'event_subscriber' }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
@@ -1,0 +1,5 @@
+services:
+  Drupal\helfi_kasko_content\EventSubscriber\UnitCategorySubscriber:
+    arguments: [ '@entity_type.manager' ]
+    tags:
+      - { name: 'event_subscriber' }

--- a/public/modules/custom/helfi_kasko_content/src/EventSubscriber/UnitCategorySubscriber.php
+++ b/public/modules/custom/helfi_kasko_content/src/EventSubscriber/UnitCategorySubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_kasko_content\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\helfi_kasko_content\UnitCategoryUtility;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigratePostRowSaveEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribe to migrate event in order to set categories field.
+ */
+class UnitCategorySubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new UnitCategorySubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      MigrateEvents::POST_ROW_SAVE => 'postRowSave',
+    ];
+  }
+
+  /**
+   * Set categories field values using ontologyword IDs.
+   */
+  public function postRowSave(MigratePostRowSaveEvent $event): void {
+    if ($event->getMigration()->id() !== 'tpr_unit') {
+      return;
+    }
+    if (empty($event->getRow()->getSourceProperty('ontologyword_ids'))) {
+      return;
+    }
+
+    $tprUnitStorage = $this->entityTypeManager->getStorage('tpr_unit');
+    $destinationIDs = $event->getDestinationIdValues();
+
+    foreach ($destinationIDs as $destinationId) {
+      $entity = $tprUnitStorage->load($destinationId);
+      if (!$entity->hasField('ontologyword_ids') || !$entity->hasField('field_categories')) {
+        continue;
+      }
+
+      $categories = [];
+      foreach ($entity->get('ontologyword_ids') as $ontologywordId) {
+        foreach (UnitCategoryUtility::getCategories($ontologywordId->get('value')->getCastedValue()) as $category) {
+          $categories[$category] = $category;
+        }
+      }
+
+      $entity->set('field_categories', array_values($categories));
+      $entity->save();
+    }
+  }
+
+}

--- a/public/modules/custom/helfi_kasko_content/src/UnitCategoryUtility.php
+++ b/public/modules/custom/helfi_kasko_content/src/UnitCategoryUtility.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_kasko_content;
+
+/**
+ * Contains helper functions for TPR Unit categories.
+ */
+class UnitCategoryUtility {
+
+  public const DAYCARE = 'daycare';
+  public const COMPREHENSIVE_SCHOOL = 'comprehensive school';
+  public const PLAYGROUND = 'playground';
+
+  /**
+   * Map categories to ontologyword IDs.
+   *
+   * @var array
+   */
+  private static array $categoryToIds = [
+    self::DAYCARE => [
+      603,
+      663,
+    ],
+    self::COMPREHENSIVE_SCHOOL => [
+      601,
+      602,
+      661,
+      662,
+    ],
+    self::PLAYGROUND => [
+      475,
+    ],
+  ];
+
+  /**
+   * Get unit categories from ontologyword ID, if defined.
+   *
+   * @param int $ontologyword_id
+   *   The ontologyword ID.
+   *
+   * @return string[]
+   *   The matching categories.
+   */
+  public static function getCategories(int $ontologyword_id) : array {
+    $categories = [];
+    foreach (self::$categoryToIds as $category => $ids) {
+      if (in_array($ontologyword_id, $ids)) {
+        $categories[] = $category;
+      }
+    }
+    return $categories;
+  }
+
+}

--- a/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_kasko_content\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\helfi_tpr\Functional\MigrationTestBase;
+use Drupal\Tests\helfi_tpr\Traits\TprMigrateTrait;
+
+/**
+ * Tests unit category permissions.
+ *
+ * @group helfi_kasko_content
+ */
+class UnitCategoryPermissionTest extends MigrationTestBase {
+
+  use TprMigrateTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_kasko_content',
+  ];
+
+  /**
+   * Tests unit category permissions for unit updates.
+   */
+  public function testCategoryPermissions() : void {
+    $this->runUnitMigrate();
+    $entityId = 1;
+
+    // Test that privileged account always has access.
+    $this->drupalLogin($this->privilegedAccount);
+    $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => $entityId]));
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Test that anonymous user has no access.
+    $this->drupalLogout();
+    $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => $entityId]));
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Test that logged-in user without special permissions has no access.
+    $this->drupalLogin($this->createUser());
+    $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => $entityId]));
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Test that user with special category-related permission has access.
+    $this->drupalLogin($this->createUser([
+      'admin daycare units',
+    ]));
+    $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => $entityId]));
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Test that user with wrong category-related permission has no access.
+    $this->drupalLogin($this->createUser([
+      'admin playground units',
+    ]));
+    $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => $entityId]));
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}

--- a/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
@@ -38,6 +38,7 @@ class UnitCategoryPermissionTest extends MigrationTestBase {
       'type' => 'string',
       'settings' => [],
       'cardinality' => -1,
+      'translatable' => '0',
     ])->save();
 
     $fieldCategoriesConfig = FieldConfig::create([
@@ -83,7 +84,6 @@ class UnitCategoryPermissionTest extends MigrationTestBase {
     $this->assertSession()->statusCodeEquals(403);
 
     // Test that user with special category-related permission has access.
-    // @todo Fix this: changes made in UnitCategorySubscriber are not shown.
     $this->drupalLogin($this->createUser([
       'admin daycare units',
     ]));

--- a/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
@@ -5,8 +5,6 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_kasko_content\Functional;
 
 use Drupal\Core\Url;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\helfi_tpr\Functional\MigrationTestBase;
 use Drupal\Tests\helfi_tpr\Traits\TprMigrateTrait;
 
@@ -32,29 +30,10 @@ class UnitCategoryPermissionTest extends MigrationTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    FieldStorageConfig::create([
-      'field_name' => 'field_categories',
-      'entity_type' => 'tpr_unit',
-      'type' => 'string',
-      'settings' => [],
-      'cardinality' => -1,
-      'translatable' => '0',
-    ])->save();
-
-    $fieldCategoriesConfig = FieldConfig::create([
-      'field_name' => 'field_categories',
-      'label' => 'Categories',
-      'entity_type' => 'tpr_unit',
-      'bundle' => 'tpr_unit',
-      'required' => FALSE,
-      'settings' => [],
-      'description' => '',
-    ]);
-    $fieldCategoriesConfig->save();
-
+    // Show Categories at the browser output.
     \Drupal::service('entity_display.repository')
-      ->getFormDisplay($fieldCategoriesConfig->getTargetEntityTypeId(), $fieldCategoriesConfig->getTargetBundle())
-      ->setComponent($fieldCategoriesConfig->getName(), [
+      ->getFormDisplay('tpr_unit', 'tpr_unit')
+      ->setComponent('field_categories', [
         'type' => 'readonly_field_widget',
       ])
       ->save();

--- a/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Functional/UnitCategoryPermissionTest.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_kasko_content\Functional;
 
 use Drupal\Core\Url;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\helfi_tpr\Functional\MigrationTestBase;
 use Drupal\Tests\helfi_tpr\Traits\TprMigrateTrait;
 
@@ -25,10 +27,44 @@ class UnitCategoryPermissionTest extends MigrationTestBase {
   ];
 
   /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_categories',
+      'entity_type' => 'tpr_unit',
+      'type' => 'string',
+      'settings' => [],
+      'cardinality' => -1,
+    ])->save();
+
+    $fieldCategoriesConfig = FieldConfig::create([
+      'field_name' => 'field_categories',
+      'label' => 'Categories',
+      'entity_type' => 'tpr_unit',
+      'bundle' => 'tpr_unit',
+      'required' => FALSE,
+      'settings' => [],
+      'description' => '',
+    ]);
+    $fieldCategoriesConfig->save();
+
+    \Drupal::service('entity_display.repository')
+      ->getFormDisplay($fieldCategoriesConfig->getTargetEntityTypeId(), $fieldCategoriesConfig->getTargetBundle())
+      ->setComponent($fieldCategoriesConfig->getName(), [
+        'type' => 'readonly_field_widget',
+      ])
+      ->save();
+
+    $this->runUnitMigrate();
+  }
+
+  /**
    * Tests unit category permissions for unit updates.
    */
   public function testCategoryPermissions() : void {
-    $this->runUnitMigrate();
     $entityId = 1;
 
     // Test that privileged account always has access.
@@ -47,6 +83,7 @@ class UnitCategoryPermissionTest extends MigrationTestBase {
     $this->assertSession()->statusCodeEquals(403);
 
     // Test that user with special category-related permission has access.
+    // @todo Fix this: changes made in UnitCategorySubscriber are not shown.
     $this->drupalLogin($this->createUser([
       'admin daycare units',
     ]));

--- a/public/modules/custom/helfi_kasko_content/tests/src/Kernel/UnitCategoryMigrationTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Kernel/UnitCategoryMigrationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_kasko_content\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\helfi_kasko_content\EventSubscriber\UnitCategorySubscriber;
+use Drupal\helfi_kasko_content\UnitCategoryUtility;
+use Drupal\helfi_tpr\Entity\Unit;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigratePostRowSaveEvent;
+use Drupal\Tests\helfi_tpr\Kernel\MigrationTestBase;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Tests TPR Unit migration for categories field.
+ *
+ * @group helfi_kasko_content
+ */
+class UnitCategoryMigrationTest extends MigrationTestBase implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() : void {
+    parent::setUp();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_categories',
+      'entity_type' => 'tpr_unit',
+      'type' => 'string',
+      'settings' => [],
+      'cardinality' => -1,
+    ])->save();
+
+    $fieldCategoriesConfig = FieldConfig::create([
+      'field_name' => 'field_categories',
+      'label' => 'Categories',
+      'entity_type' => 'tpr_unit',
+      'bundle' => 'tpr_unit',
+      'required' => FALSE,
+      'settings' => [],
+      'description' => '',
+    ]);
+    $fieldCategoriesConfig->save();
+
+    $this->runUnitMigrate();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      MigrateEvents::POST_ROW_SAVE => 'postRowSave',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+    $container
+      ->register('helfi_kasko_content.migrate_subscriber', self::class)
+      ->addTag('event_subscriber');
+    $container->set('helfi_kasko_content.migrate_subscriber', $this);
+  }
+
+  /**
+   * Use UnitCategorySubscriber to handle migration event.
+   */
+  public function postRowSave(MigratePostRowSaveEvent $event) : void {
+    (new UnitCategorySubscriber(\Drupal::service('entity_type.manager')))->postRowSave($event);
+  }
+
+  /**
+   * Tests unit category mapping to ontologyword IDs.
+   */
+  public function testUnitCategories() : void {
+    $expectedResults = [
+      60321 => [],
+      67763 => [],
+      63115 => [],
+      1 => [
+        UnitCategoryUtility::COMPREHENSIVE_SCHOOL,
+        UnitCategoryUtility::DAYCARE,
+      ],
+      59369 => [],
+    ];
+
+    foreach ($expectedResults as $entityId => $expectedCategories) {
+      $unitCategories = [];
+      foreach (Unit::load($entityId)->get('field_categories')->getValue() as $value) {
+        if (!empty($value['value'])) {
+          $unitCategories[] = $value['value'];
+        }
+      }
+
+      foreach ($expectedCategories as $expectedCategory) {
+        $this->assertContains($expectedCategory, $unitCategories);
+      }
+    }
+  }
+
+}

--- a/public/modules/custom/helfi_kasko_content/tests/src/Kernel/UnitCategoryMigrationTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Kernel/UnitCategoryMigrationTest.php
@@ -11,7 +11,7 @@ use Drupal\helfi_kasko_content\EventSubscriber\UnitCategorySubscriber;
 use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\helfi_tpr\Entity\Unit;
 use Drupal\migrate\Event\MigrateEvents;
-use Drupal\migrate\Event\MigratePostRowSaveEvent;
+use Drupal\migrate\Event\MigratePreRowSaveEvent;
 use Drupal\Tests\helfi_tpr\Kernel\MigrationTestBase;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -55,7 +55,7 @@ class UnitCategoryMigrationTest extends MigrationTestBase implements EventSubscr
    */
   public static function getSubscribedEvents() : array {
     return [
-      MigrateEvents::POST_ROW_SAVE => 'postRowSave',
+      MigrateEvents::PRE_ROW_SAVE => 'preRowSave',
     ];
   }
 
@@ -73,8 +73,8 @@ class UnitCategoryMigrationTest extends MigrationTestBase implements EventSubscr
   /**
    * Use UnitCategorySubscriber to handle migration event.
    */
-  public function postRowSave(MigratePostRowSaveEvent $event) : void {
-    (new UnitCategorySubscriber(\Drupal::service('entity_type.manager')))->postRowSave($event);
+  public function preRowSave(MigratePreRowSaveEvent $event) : void {
+    (new UnitCategorySubscriber())->preRowSave($event);
   }
 
   /**


### PR DESCRIPTION
# [UHF-6317](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6317)

## What was done
* Added new `field_categories` field for TPR units.
* During the migration, `field_categories` is set using source data ontologyword IDs.
  * The categories field hold values such as `daycare` to inform that the TPR unit is, in fact, a daycare unit.
* Added three new permissions and roles that use those permissions.
  * The new permissions are used to limit a user to only edit specific type of TPR units.
* Also renamed the school editor label.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git co UHF-6317-separate-tpr-unit-roles`
  *  `make shell` and
      * `composer require drupal/helfi_tpr:dev-UHF-6317-permissions-by-ontology`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Update TPR units by running the migration.
  * `drush shell` and
      * `drush migrate:import tpr_unit`
* You can now see a list of the Ontologyword IDs at the bottom of the unit's edit form.
* You can also see a list of categories (e.g. daycare) if the unit is daycare, comprehensive school or playground.
* Create three new users and give one of the new permissions for each: Daycare editor, Comprehensive school editor, Playground editor.
* Log-in with the new users and check that they can only edit the equivalent TPR units, e.g. the user with Daycare editor role can edit daycare unit pages.
* Check that the new users have reasonable permissions so that they can add and remove media, etc.
* Check that also the translated units work correctly.

Note: Tests are failing until there is a new helfi_tpr release. However, you can run the new tests:
* `make shell` and
  * `vendor/bin/phpunit -c /app/phpunit.xml.dist /app/public/modules/custom`

Also check the code of the linked PR.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/127
