### PR TITLE
UHF-6917: Elementary school search backend

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -25,6 +25,7 @@ module:
   easy_breadcrumb: 0
   editor: 0
   editoria11y: 0
+  elasticsearch_connector: 0
   entity: 0
   entity_reference_revisions: 0
   entity_usage: 0
@@ -118,6 +119,7 @@ module:
   rest: 0
   role_delegation: 0
   scheduler: 0
+  search_api: 0
   select2: 0
   select2_icon: 0
   serialization: 0

--- a/conf/cmi/elasticsearch_connector.cluster.elastic_kasko.yml
+++ b/conf/cmi/elasticsearch_connector.cluster.elastic_kasko.yml
@@ -1,0 +1,19 @@
+uuid: 49404e73-70f3-4f7a-b447-c8d7271a0439
+langcode: en
+status: '1'
+dependencies: {  }
+cluster_id: elastic_kasko
+name: 'Elastic Kasko'
+url: 'http://elastic:9200'
+options:
+  multiple_nodes_connection: false
+  use_authentication: 1
+  authentication_type: Basic
+  username: ''
+  password: ''
+  timeout: '3'
+  rewrite:
+    rewrite_index: 1
+    index:
+      prefix: ''
+      suffix: ''

--- a/conf/cmi/search_api.index.comprehensive_schools.yml
+++ b/conf/cmi/search_api.index.comprehensive_schools.yml
@@ -14,6 +14,14 @@ name: 'Comprehensive schools'
 description: ''
 read_only: false
 field_settings:
+  address_line1:
+    label: 'Address » The first line of the address block'
+    datasource_id: 'entity:tpr_unit'
+    property_path: 'address:address_line1'
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
   categories:
     label: Categories
     datasource_id: 'entity:tpr_unit'
@@ -22,6 +30,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.tpr_unit.field_categories
+  description:
+    label: Description
+    datasource_id: 'entity:tpr_unit'
+    property_path: description
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
   id:
     label: ID
     datasource_id: 'entity:tpr_unit'
@@ -34,6 +50,14 @@ field_settings:
     label: Name
     datasource_id: 'entity:tpr_unit'
     property_path: name
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
+  picture_url:
+    label: Picture
+    datasource_id: 'entity:tpr_unit'
+    property_path: picture_url
     type: string
     dependencies:
       module:

--- a/conf/cmi/search_api.index.comprehensive_schools.yml
+++ b/conf/cmi/search_api.index.comprehensive_schools.yml
@@ -1,0 +1,63 @@
+uuid: b5f4bf13-8539-4d80-8d9f-2fbdbd18d192
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.tpr_unit.field_categories
+    - search_api.server.elastic_kasko
+  module:
+    - helfi_tpr
+    - search_api
+    - helfi_kasko_content
+id: comprehensive_schools
+name: 'Comprehensive schools'
+description: ''
+read_only: false
+field_settings:
+  field_categories:
+    label: Categories
+    datasource_id: 'entity:tpr_unit'
+    property_path: field_categories
+    type: string
+    dependencies:
+      config:
+        - field.storage.tpr_unit.field_categories
+  name:
+    label: Name
+    datasource_id: 'entity:tpr_unit'
+    property_path: name
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
+  postal_code:
+    label: 'Address » The postal code'
+    datasource_id: 'entity:tpr_unit'
+    property_path: 'address:postal_code'
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
+datasource_settings:
+  'entity:tpr_unit':
+    languages:
+      default: false
+      selected:
+        - en
+        - fi
+        - sv
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  entity_type: {  }
+  language_with_fallback: {  }
+  rendered_item: {  }
+  search_api_exclude_items_from_index: {  }
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  cron_limit: 50
+  index_directly: true
+  track_changes_in_references: true
+server: elastic_kasko

--- a/conf/cmi/search_api.index.comprehensive_schools.yml
+++ b/conf/cmi/search_api.index.comprehensive_schools.yml
@@ -14,7 +14,7 @@ name: 'Comprehensive schools'
 description: ''
 read_only: false
 field_settings:
-  field_categories:
+  categories:
     label: Categories
     datasource_id: 'entity:tpr_unit'
     property_path: field_categories
@@ -22,6 +22,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.tpr_unit.field_categories
+  id:
+    label: ID
+    datasource_id: 'entity:tpr_unit'
+    property_path: id
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
   name:
     label: Name
     datasource_id: 'entity:tpr_unit'
@@ -49,6 +57,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  entity_status: {  }
   entity_type: {  }
   language_with_fallback: {  }
   rendered_item: {  }

--- a/conf/cmi/search_api.index.comprehensive_schools.yml
+++ b/conf/cmi/search_api.index.comprehensive_schools.yml
@@ -14,7 +14,7 @@ name: 'Comprehensive schools'
 description: ''
 read_only: false
 field_settings:
-  address_line1:
+  address:
     label: 'Address » The first line of the address block'
     datasource_id: 'entity:tpr_unit'
     property_path: 'address:address_line1'

--- a/conf/cmi/search_api.server.elastic_kasko.yml
+++ b/conf/cmi/search_api.server.elastic_kasko.yml
@@ -1,0 +1,14 @@
+uuid: e1c5dd15-1abe-4c47-8f18-214fbccf5aeb
+langcode: en
+status: true
+dependencies:
+  module:
+    - elasticsearch_connector
+id: elastic_kasko
+name: 'Elastic Kasko'
+description: ''
+backend: elasticsearch
+backend_config:
+  cluster_settings:
+    cluster: elastic_kasko
+  fuzziness: auto

--- a/conf/cmi/search_api.settings.yml
+++ b/conf/cmi/search_api.settings.yml
@@ -1,0 +1,28 @@
+_core:
+  default_config_hash: b2zIRm9Jv3SB60NYdZkZHxH8-KdEa-Xa48-4NsIi4lg
+default_cron_limit: 50
+cron_worker_runtime: 15
+default_tracker: default
+tracking_page_size: 100
+boost_factors:
+  - !!float 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - !!float 1
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - !!float 2
+  - !!float 3
+  - !!float 5
+  - !!float 8
+  - !!float 13
+  - !!float 21

--- a/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
+++ b/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\helfi_kasko_content\Plugin\search_api\processor;
 
+use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -38,17 +39,9 @@ class SearchApiExcludeItemsFromIndex extends ProcessorPluginBase {
   public function alterIndexedItems(array &$items) {
     /** @var \Drupal\search_api\Item\ItemInterface $item */
     foreach ($items as $item_id => $item) {
-      $object = $item->getOriginalObject()->getValue();
+      $unit = $item->getOriginalObject()->getValue();
 
-      $categories = $object->get('field_categories')->getValue();
-
-      $unit_categories = [];
-
-      foreach ($categories as $category) {
-        $unit_categories[] = $category['value'];
-      }
-
-      if (!in_array('comprehensive school', $unit_categories)) {
+      if (!UnitCategoryUtility::entityHasCategory($unit, UnitCategoryUtility::COMPREHENSIVE_SCHOOL)) {
         unset($items[$item_id]);
         continue;
       }

--- a/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
+++ b/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @SearchApiProcessor(
  *   id = "search_api_exclude_items_from_index",
- *   label = @Translation("Exclude items from Search API index - TPR Units),
+ *   label = @Translation("Exclude items from Search API index - TPR Units"),
  *   description = @Translation("Excludes all but comprehensive school TPR units from being indexed."),
  *   stages = {
  *     "alter_items" = -50

--- a/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
+++ b/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\helfi_kasko_content\Plugin\search_api\processor;
+
+use Drupal\search_api\Plugin\PluginFormTrait;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Excludes all but comprehensive school TPR units from being indexed.
+ *
+ * @SearchApiProcessor(
+ *   id = "search_api_exclude_items_from_index",
+ *   label = @Translation("Exclude items from Search API index - TPR Units),
+ *   description = @Translation("Excludes all but comprehensive school TPR units from being indexed."),
+ *   stages = {
+ *     "alter_items" = -50
+ *   }
+ * )
+ */
+class SearchApiExcludeItemsFromIndex extends ProcessorPluginBase {
+
+  use PluginFormTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    /** @var \Drupal\search_api\Item\ItemInterface $item */
+    foreach ($items as $item_id => $item) {
+      $object = $item->getOriginalObject()->getValue();
+
+      $categories = $object->get('field_categories')->getValue();
+
+      $unit_categories = [];
+
+      foreach ($categories as $category) {
+        $unit_categories[] = $category['value'];
+      }
+
+      if (!in_array('comprehensive school', $unit_categories)) {
+        unset($items[$item_id]);
+        continue;
+      }
+    }
+  }
+
+}

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -14,3 +14,18 @@ if ($drush_options_uri = getenv('DRUSH_OPTIONS_URI')) {
     $config['helfi_proxy.settings']['default_proxy_domain'] = 'www.hel.fi';
   }
 }
+
+// Elasticsearch settings.
+if (getenv('ELASTICSEARCH_URL')) {
+  $config['elasticsearch_connector.cluster.elastic_kasko']['url'] = getenv('ELASTICSEARCH_URL');
+
+  if (getenv('ELASTIC_USER') && getenv('ELASTIC_PASSWORD')) {
+    $config['elasticsearch_connector.cluster.elastic_kasko']['options']['use_authentication'] = '1';
+    $config['elasticsearch_connector.cluster.elastic_kasko']['options']['authentication_type'] = 'Basic';
+    $config['elasticsearch_connector.cluster.elastic_kasko']['options']['username'] = getenv('ELASTIC_USER');
+    $config['elasticsearch_connector.cluster.elastic_kasko']['options']['password'] = getenv('ELASTIC_PASSWORD');
+  }
+}
+
+// Elastic proxy URL.
+$config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_URL');


### PR DESCRIPTION
# [UHF-6917](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6917)
<!-- What problem does this solve? -->

## What was done
- Enabled `elasticsearch_connector` and `search_api` modules
- Added Elasticsearch cluster and search API index for TPR units
- Filtering out all but published comprehensive school units from the index
- Added config to `all.settings.php`

## How to install
1. Set up KASKO instance
2. Checkout this branch: `git checkout UHF-6917_elementary_school_search_backend`
3. Import config: `make drush-cim`

## How to test
1. Migrate & update all the TPR units: `make shell` & `drush mim tpr_unit --update` (takes a while)
2. In `/admin/content/integrations/tpr-unit`, search for comprehensive schools with "peruskoulu" and publish all or some of the units
3. In `/admin/config/search/search-api/index/comprehensive_schools`, click "Index now" and wait for the units to be added to the index
4. Access `http://localhost:9217/comprehensive_schools/_search` and confirm that there are units in the index (NOTE! The Elastic port number may vary, see `make ps` to see the correct one)

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
