### PR TITLE
UHF-7862: bump proxy version from 2.3 to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drupal/helfi_hauki": "^1.0",
         "drupal/helfi_navigation": "^1.0",
         "drupal/helfi_platform_config": "^2.0",
-        "drupal/helfi_proxy": "^2.0",
+        "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tpr": "^2.0",
         "drupal/helfi_tunnistamo": "^2.0",
         "drupal/override_node_options": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4319f1f9a1573a2691c5fe3bdfef04e2",
+    "content-hash": "573cda2cc2c64bf0b3b6e037bf124a87",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4677,16 +4677,16 @@
         },
         {
             "name": "drupal/helfi_proxy",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy.git",
-                "reference": "cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7"
+                "reference": "569383371028ec22e3a82c9ebc2c20ddced5a075"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-proxy/zipball/cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7",
-                "reference": "cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-proxy/zipball/569383371028ec22e3a82c9ebc2c20ddced5a075",
+                "reference": "569383371028ec22e3a82c9ebc2c20ddced5a075",
                 "shasum": ""
             },
             "require": {
@@ -4711,10 +4711,10 @@
             ],
             "description": "Provides various fixes so we can serve multiple Drupal instances in one domain.",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/tree/2.3.0",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/tree/3.0.0",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/issues"
             },
-            "time": "2022-11-08T11:03:23+00:00"
+            "time": "2022-11-10T04:53:14+00:00"
         },
         {
             "name": "drupal/helfi_tpr",


### PR DESCRIPTION
Updated proxy to prevent js error with paragraphs