### PR TITLE
UHF-7241: Breadcrumb translation fixes

### DIFF
--- a/conf/cmi/language/sv/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/sv/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: 'Fostran and utbildning'
+home_segment_title: 'Fostran och utbildning'

--- a/conf/cmi/language/sv/helfi_proxy.settings.yml
+++ b/conf/cmi/language/sv/helfi_proxy.settings.yml
@@ -1,1 +1,1 @@
-front_page_title: 'Fostran and utbildning'
+front_page_title: 'Fostran och utbildning'

--- a/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
+++ b/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
@@ -1,1 +1,1 @@
-label: Startsida
+label: Huvudsida


### PR DESCRIPTION
# [UHF-7241](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241)
In some cases, the breadcrumb has _Fostran and utbildning_ instead of _Fostran och utbildning_.
The front page in the breadcrumb is Startsida instead of Huvudsida.

## What was done
* Fixed the above issues by updating configs.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7241_Kasko-breadcrumb-fixes`
* Run `make drush-cr`

## How to test
* [ ] Check that the front page in the breadcrumb on Swedish pages is **Huvudsida**
* [ ] **Childhood and education** on Swedish breadcrumb is **Fostran and utbildning**

## Designers review
* [x] This PR does not need designers review

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/116
https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/391
https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/186
https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/188
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/568
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/508
https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/181
https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/290


[UHF-7241]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ