### PR TITLE
UHF-6839: Address filter

### DIFF
--- a/conf/cmi/search_api.index.schools.yml
+++ b/conf/cmi/search_api.index.schools.yml
@@ -21,6 +21,18 @@ field_settings:
     dependencies:
       module:
         - helfi_tpr
+  coordinates:
+    label: Coordinates
+    property_path: coordinates
+    type: object
+  id:
+    label: ID
+    datasource_id: 'entity:tpr_unit'
+    property_path: id
+    type: string
+    dependencies:
+      module:
+        - helfi_tpr
   media_as_objects:
     label: 'Media objects'
     property_path: media_as_objects
@@ -71,6 +83,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  coordinates: {  }
   entity_type: {  }
   is_school: {  }
   language_with_fallback: {  }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.info.yml
@@ -7,4 +7,5 @@ dependencies:
   - drupal:content_translation
   - drupal:language
   - drupal:taxonomy
+  - elasticsearch_connector:elasticsearch_connector
   - helfi_tpr:helfi_tpr

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.services.yml
@@ -2,3 +2,6 @@ services:
   Drupal\helfi_kasko_content\EventSubscriber\UnitCategorySubscriber:
     tags:
       - { name: 'event_subscriber' }
+  Drupal\helfi_kasko_content\EventSubscriber\MappingSubscriber:
+    tags:
+      - { name: 'event_subscriber' }

--- a/public/modules/custom/helfi_kasko_content/src/EventSubscriber/MappingSubscriber.php
+++ b/public/modules/custom/helfi_kasko_content/src/EventSubscriber/MappingSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_kasko_content\EventSubscriber;
+
+use Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribe to index mapping event for needed changes.
+ */
+class MappingSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      PrepareIndexMappingEvent::PREPARE_INDEX_MAPPING => 'addCoordinatesField',
+    ];
+  }
+
+  /**
+   * Set mapping for unit's coordinates as geo_point field.
+   *
+   * @param Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent $event
+   *   Event emitted by elasticsearch_connector.
+   */
+  public function addCoordinatesField(PrepareIndexMappingEvent $event): void {
+    $params = $event->getIndexMappingParams();
+
+    if ($params['index'] !== 'schools') {
+      return;
+    }
+
+    $params['body']['properties']['coordinates'] = [
+      'type' => 'geo_point',
+    ];
+
+    $event->setIndexMappingParams($params);
+  }
+
+}


### PR DESCRIPTION
# [UHF-6839](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6839)
Extend school search app to allow searching by address.

## What was done
<!-- Describe what was done -->

In this repo:
- Add changes to school index
- Add subscriber to transform coordinates field to geo field in elastic

In HDBT: https://github.com/City-of-Helsinki/drupal-hdbt/pull/548
In Platform Config: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/438

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout origin/UHF-6839-address-filter`
* Run `make ps`. Note which port your Elastic container is running in. Add this value to `.env` in the `ELASTIC_PROXY_URL` variable.` 
* Install dependencies:
  * `composer require drupal/hdbt:dev-UHF-6839-adress-filter drupal/helfi_platform_config:dev-UHF-6839-adress-filter`
* Run `make fresh`
* Run `drush sapi-rt; drush sapi-i` to buld index
* Run `drush cr` for good measure

## How to test

* Add or edit a landing page
* Add a "School search" paragraph to the page
* Try looking up some valid / invalid addresses (located in Helsinki)
  * Valid addresses should show ome school options
  * Invalid addresses should show no results
* Check that pagination works

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/548
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/438


[UHF-6839]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ