### PR TITLE
UHF-8075: Fix high school cards linking

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -5,7 +5,6 @@
  * Functions to support theming in the HDBT Subtheme.
  */
 
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
 use Drupal\helfi_group\GroupUtility;
@@ -169,7 +168,8 @@ function hdbt_subtheme_preprocess_tpr_unit(&$variables) {
     $url = Url::fromRoute('entity.node.canonical', ['node' => $nid]);
     $variables['high_school_card_url'] = $url;
     $variables['high_school_front_page_title'] = $title;
-  } elseif (
+  }
+  elseif (
     $entity->hasField('field_hs_front_page') &&
     $entity->hasField('www') &&
     $entity->field_hs_front_page->isEmpty() &&
@@ -184,7 +184,8 @@ function hdbt_subtheme_preprocess_tpr_unit(&$variables) {
     $resolver = \Drupal::service('helfi_api_base.internal_domain_resolver');
     $variables['high_school_card_url_external'] = $resolver->isExternal($url);
     $variables['high_school_card_url'] = $url;
-  } else {
+  }
+  else {
     $variables['high_school_card_url'] = !$entity->isNew() ? $entity->toUrl('canonical') : NULL;
   }
 }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -5,7 +5,9 @@
  * Functions to support theming in the HDBT Subtheme.
  */
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Url;
 use Drupal\helfi_group\GroupUtility;
 use Drupal\helfi_tpr\Entity\Unit;
 use Drupal\node\Entity\Node;
@@ -164,8 +166,26 @@ function hdbt_subtheme_preprocess_tpr_unit(&$variables) {
   ) {
     $nid = $entity->field_hs_front_page->entity->id();
     $title = $entity->field_hs_front_page->entity->getTitle();
-    $variables['high_school_front_page_nid'] = $nid;
+    $url = Url::fromRoute('entity.node.canonical', ['node' => $nid]);
+    $variables['high_school_card_url'] = $url;
     $variables['high_school_front_page_title'] = $title;
+  } elseif (
+    $entity->hasField('field_hs_front_page') &&
+    $entity->hasField('www') &&
+    $entity->field_hs_front_page->isEmpty() &&
+    !$entity->www->isEmpty()
+  ) {
+    $uri = $entity->get('www')->first()->getValue()['uri'];
+    $url = Url::fromUri($uri);
+
+    // Check if current link is external (not whitelisted) and
+    // set data attributes accordingly.
+    /** @var \Drupal\helfi_api_base\Link\InternalDomainResolver $resolver */
+    $resolver = \Drupal::service('helfi_api_base.internal_domain_resolver');
+    $variables['high_school_card_url_external'] = $resolver->isExternal($url);
+    $variables['high_school_card_url'] = $url;
+  } else {
+    $variables['high_school_card_url'] = !$entity->isNew() ? $entity->toUrl('canonical') : NULL;
   }
 }
 

--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -20,8 +20,14 @@
 
   {% if view_mode == 'high_school_card' %}
     {% set view_mode_class = 'card--high-school-teaser' %}
+    {% set unit_url = high_school_card_url %}
+    {% set unit_url_external = false %}
+    {% if high_school_card_url_external %}
+      {% set unit_url_external = true %}
+    {% endif %}
   {% else %}
     {% set view_mode_class = 'card--vocational-school-teaser' %}
+    {% set unit_url_external = false %}
   {% endif %}
 
   {% embed '@hdbt/component/card.twig' with {
@@ -29,6 +35,7 @@
     card_image: card_image,
     card_title: card_title,
     card_url: unit_url,
+    card_url_external: unit_url_external,
     card_description: content.description_summary,
     card_tags: card_tags,
     card_metas: [


### PR DESCRIPTION
# [UHF-8075](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8075)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Re-added functionality that was accidentally removed. The functionality makes it possible to add "front page" for the high schools. If front page is not set and www-page is then the high school cards link to that url. If that is not set either then it should link to unit-page. Before the fix all the cards linked to unit-pages.
* The PR where the functionality was removed and where you can check how it was implemented earlier: https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/278

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8075_fix_high_school_card_linking`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to `https://helfi-kasko.docker.so/en/childhood-and-education/general-upper-secondary-education/general-upper-secondary-schools` and make sure the high school cards link to high schools web pages.
* [x] Go edit one of the high schools and add standard page or landing page to the "High school front page" field. After saving the high school card should link to this page.
* [x] Check that code follows our standards.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-8075]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ