### PR TITLE
UHF-6840: Index only published schools

### DIFF
--- a/conf/cmi/search_api.index.schools.yml
+++ b/conf/cmi/search_api.index.schools.yml
@@ -84,6 +84,7 @@ processor_settings:
   add_url: {  }
   aggregated_field: {  }
   coordinates: {  }
+  entity_status: {  }
   entity_type: {  }
   is_school: {  }
   language_with_fallback: {  }


### PR DESCRIPTION
# [UHF-6840](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6840)
Enable users to view search results on map.

## What was done

In this PR:
- Change "schools" index settings so that only published units are displayed (desired state for final version)

In HDBT PR (https://github.com/City-of-Helsinki/drupal-hdbt/pull/558)
* Add button for showing embed of service map containing all units in the search results
* Add some styles for search results top area

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout origin/UHF-6840-results-on-map`
* Run `make ps`. Note which port your Elastic container is running in. Add this value to `.env` in the `ELASTIC_PROXY_URL` variable.` 
* Install HDBT dependency:
  * `composer require drupal/hdbt:dev-UHF-6840-results-on-map`
* Run `make fresh`
* Run `drush sapi-c; drush sapi-rt; drush sapi-i` to buld index
* Run `drush cr` for good measure

## How to test

* Sesarch for schools via a valid Helsinki address
* Click on the button 'show results on map' after the search is concluded
* This should open an embed of the map tool which should list the schools in a map view
* Clicking the 'Open larger map' button should take you to a larger view of the map
* Switching between list / map state should be easy

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-6840]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ