### PR TITLE
UHF-8290: added current language parameter to token

### DIFF
--- a/public/modules/custom/helfi_group/helfi_group.tokens.inc
+++ b/public/modules/custom/helfi_group/helfi_group.tokens.inc
@@ -5,6 +5,7 @@
  * Builds extra placeholder replacement tokens for groups.
  */
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\helfi_group\GroupUtility;
 
@@ -62,7 +63,9 @@ function helfi_group_tokens($type, $tokens, array $data, array $options, Bubblea
         }
 
         // Use news parent translation that matches the current language.
-        $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+        $langcode = \Drupal::languageManager()
+          ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+          ->getId();
         /** @var \Drupal\Core\Entity\EntityInterface $newsParent */
         if ($newsParent->hasTranslation($langcode)) {
           $newsParent = $newsParent->getTranslation($langcode);


### PR DESCRIPTION
Updated currentLanguage parameter for group tokens.

Go to fi/kasvatus-ja-koulutus/alppilan-lukio and see the news under "ajankohtaista" title.