### PR TITLE
UHF-7322: Translations for Group

### DIFF
--- a/conf/cmi/language/fi/views.view.group_nodes.yml
+++ b/conf/cmi/language/fi/views.view.group_nodes.yml
@@ -1,4 +1,4 @@
-label: 'Ryhmän solmut'
+label: 'Ryhmän sisällöt'
 display:
   default:
     display_title: Oletus


### PR DESCRIPTION
# [UHF-7322](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7322)
<!-- What problem does this solve? -->

Group content edit form had wrong translation for "Group nodes"

## What was done
<!-- Describe what was done -->

* Translated edit form tab "Group nodes" to "Ryhmät sisällöt".

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7322_Group_translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check translation for "Group nodes" on group content edit page
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review


[UHF-7322]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ