### PR TITLE
UHF-8379: Updated permissions of upper secondary school editor

### DIFF
--- a/conf/cmi/user.role.school_editor.yml
+++ b/conf/cmi/user.role.school_editor.yml
@@ -24,6 +24,7 @@ dependencies:
     - scheduler
     - system
     - toolbar
+    - view_unpublished
 id: school_editor
 label: 'Upper secondary school editor'
 weight: -4
@@ -65,6 +66,7 @@ permissions:
   - 'use text format full_html'
   - 'use text format minimal'
   - 'view all media revisions'
+  - 'view any unpublished content'
   - 'view editoria11y checker'
   - 'view own unpublished content'
   - 'view own unpublished media'


### PR DESCRIPTION
# [UHF-8379](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8379)
<!-- What problem does this solve? -->
Upper secondary school editors can't see unpublished news on their group's landing page.

## What was done
<!-- Describe what was done -->

* Added a permission to see unpublished content.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8379_Upper-secondary-school-editor-permissions`
  * `make fresh`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add unpublished news to any group, for example: https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/kallion-lukio. Check that page with an user who has "Upper secondary school editor" role. The unpublished news should be visible.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8379]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ