### PR TITLE
UHF-8463: Changed high school news listings to be sorted in descending publish date order

### DIFF
--- a/conf/cmi/views.view.group_news_archive.yml
+++ b/conf/cmi/views.view.group_news_archive.yml
@@ -112,15 +112,15 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        created:
-          id: created
+        published_at:
+          id: published_at
           table: node_field_data
-          field: created
+          field: published_at
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: created
+          entity_field: published_at
           plugin_id: date
           order: DESC
           expose:

--- a/conf/cmi/views.view.latest_group_news.yml
+++ b/conf/cmi/views.view.latest_group_news.yml
@@ -96,15 +96,15 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        created:
-          id: created
+        published_at:
+          id: published_at
           table: node_field_data
-          field: created
+          field: published_at
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: created
+          entity_field: published_at
           plugin_id: date
           order: DESC
           expose:


### PR DESCRIPTION
# [UHF-8463](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8463)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed high school news listings views to be sorted in descending publish date order.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8463_high_school_news_listing_sorts`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any high school front page that has news listed for example https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/helsingin-kuvataidelukio
* [ ] You should see that the news listing is now in descending publish date order. Also if you click on the all news link on the block and check the listing that is opened it should be sorted the same way.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8463]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ