### PR TITLE
UHF-8390 D10 deprecation

### DIFF
--- a/public/modules/custom/helfi_group/helfi_group.info.yml
+++ b/public/modules/custom/helfi_group/helfi_group.info.yml
@@ -2,8 +2,7 @@ name: 'HELfi Group'
 type: module
 description: 'Provides Group module customization.'
 package: HELfi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - group
   - group_content_menu

--- a/public/modules/custom/helfi_group/src/UnitFormAlter.php
+++ b/public/modules/custom/helfi_group/src/UnitFormAlter.php
@@ -145,6 +145,7 @@ class UnitFormAlter extends NodeFormAlter {
         ->condition('menu_name', $menuNames, 'IN')
         ->sort('id')
         ->range(0, 1)
+        ->accessCheck(FALSE)
         ->execute();
 
       $menuLink = empty($results) ? MenuLinkContent::create([]) : MenuLinkContent::load(reset($results));

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
@@ -3,7 +3,7 @@ description: Subtheme for Helsinki Drupal instances.
 type: theme
 base theme: hdbt
 tags: sub-theme
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 screenshot: hdbt_subtheme.png
 'interface translation project': hdbt_subtheme
 'interface translation server pattern': themes/custom/hdbt_subtheme/translations/%language.po


### PR DESCRIPTION
Updated custom module / theme core version requirements
Added explicit access check to entity query

Setup as you would normally using this branch

How to test:
run `composer require drupal/upgrade_status` and `drush en -y upgrade_status`
Running these commands below should only yield prophesy/prophesize errors:
run `drush upgrade_status:analyze helfi_group`
run `drush upgrade_status:analyze hdbt_subtheme`