### PR TITLE
UHF-X: Revert unwanted changes from the TPR unit default display

### DIFF
--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.field.tpr_unit.tpr_unit.field_categories
     - field.field.tpr_unit.tpr_unit.field_content
-    - field.field.tpr_unit.tpr_unit.field_districts
     - field.field.tpr_unit.tpr_unit.field_hs_front_page
     - field.field.tpr_unit.tpr_unit.field_lower_content
     - field.field.tpr_unit.tpr_unit.field_metatags
@@ -19,8 +18,9 @@ dependencies:
     - paragraphs
     - path
     - readonly_field_widget
+    - select2
 _core:
-  default_config_hash: cotjiL17Qafj5pirtPax237aflvFs_-3pKHSP6wblrg
+  default_config_hash: g-ZdiLH0rHr8Mv6vni5A3v5v2UQGRdwiwPxs88WA93E
 id: tpr_unit.tpr_unit.default
 targetEntityType: tpr_unit
 bundle: tpr_unit
@@ -106,6 +106,16 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  field_categories:
+    type: readonly_field_widget
+    weight: 39
+    region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   field_content:
     type: paragraphs
     weight: 27
@@ -124,6 +134,16 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
+    third_party_settings: {  }
+  field_hs_front_page:
+    type: entity_reference_autocomplete
+    weight: 29
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_lower_content:
     type: paragraphs
@@ -151,6 +171,16 @@ content:
     settings:
       sidebar: false
     third_party_settings: {  }
+  field_study_field:
+    type: select2_entity_reference
+    weight: 31
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
   field_unit_type:
     type: entity_reference_autocomplete
     weight: 28
@@ -160,6 +190,13 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  hide_description:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   hide_sidebar_navigation:
     type: boolean_checkbox
@@ -315,10 +352,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_categories: true
   field_districts: true
-  field_hs_front_page: true
-  field_study_field: true
-  hide_description: true
   ontologyword_ids: true
-  show_www: true


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Reverted the core.entity_form_display.tpr_unit.tpr_unit.default.yml file changes that were accidentally merged to dev.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_revert_unwanted_changes_for_tpr_unit_display`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that when you are editing a TPR unit you can now see the fields "Unit type", "High school front page" and "Study field". Also check that there is the "Hide description" checkbox visible.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

