### PR TITLE
UHF-X: Enable jquery ui draggable

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -98,6 +98,7 @@ module:
   imagemagick: 0
   jquery_ui: 0
   jquery_ui_datepicker: 0
+  jquery_ui_draggable: 0
   jquery_ui_slider: 0
   jquery_ui_touch_punch: 0
   language: 0


### PR DESCRIPTION
UHF-X: Enable jquery ui draggable
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Enable jquery ui draggable to avoid issues with automatic updates.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_enable_jquery_ui_draggable`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the site still works.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
