### PR TITLE
UHF-8615 install FP before group module update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "drupal/better_exposed_filters": "^6.0",
         "drupal/core": "^9.4",
         "drupal/core-composer-scaffold": "^9.4",
+        "drupal/flexible_permissions": "^1.0",
         "drupal/group": "^1.4",
         "drupal/group_content_menu": "^1.1",
         "drupal/hdbt": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df9a416fe3fd97aebe23ff6ff047288a",
+    "content-hash": "f5545225b76b44fc206247dddbda62e3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3517,6 +3517,58 @@
             "support": {
                 "source": "https://cgit.drupalcode.org/filelog",
                 "issues": "https://www.drupal.org/project/issues/filelog"
+            }
+        },
+        {
+            "name": "drupal/flexible_permissions",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/flexible_permissions.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/flexible_permissions-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "a48740d2edcb04bb0d750c5d5c41ce8fb9acc332"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10",
+                "drupal/variationcache": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1679575763",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Kristiaan Van den Eynde",
+                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Mathias Wächter",
+                    "homepage": "https://www.drupal.org/u/mef",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module allows you to gather, calculate and cache permissions from a myriad of sources",
+            "homepage": "http://drupal.org/project/flexible_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/flexible_permissions",
+                "issues": "https://drupal.org/project/issues/flexible_permissions"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -35,6 +35,7 @@ module:
   file: 0
   file_mdm: 0
   filter: 0
+  flexible_permissions: 0
   flysystem: 0
   flysystem_azure: 0
   focal_point: 0


### PR DESCRIPTION
# [UHF-8615](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8615)

Flexible permissions module must be installed before group module D10 update.
Otherwise the group module update deployment will fail.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8615_pre`
  * `make fresh`
* Run `make drush-cr`


[UHF-8615]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ