### PR TITLE
UHF-X: Fix config_ignore settings to ignore the calculator settings correctly

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -5,4 +5,4 @@ ignored_config_entities:
   - 'hdbt_admin_tools.site_settings:site_settings'
   - 'easy_breadcrumb.settings:home_segment_title'
   - 'field.storage.paragraph.field_calculator:settings.allowed_values'
-  - helfi_calculator.calculator_settings
+  - helfi_calculator.settings


### PR DESCRIPTION
# Fix config_ignore settings to ignore the calculator settings correctly
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The config ignore settings for calculator settings was wrong so fixed it to point to correct settings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_config_ignore_settings_for_calculators`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to edit calculator settings on https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/admin/tools/calculator-settings and enable one of the calculators.
* [ ] Run `make drush-cim drush-cr` and make sure that your changes didn't get reverted.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/612