### PR TITLE
UHF-8728: Group sidebar navigation layout fix

### DIFF
--- a/public/modules/custom/helfi_group/templates/block--group-content-menu.html.twig
+++ b/public/modules/custom/helfi_group/templates/block--group-content-menu.html.twig
@@ -46,6 +46,9 @@
       {% set link_attributes = {
         'id': section_menu_title_link,
         'aria-current':  section_menu_title_current,
+        'class': [
+          'sidebar-navigation__title-link',
+        ],
       } %}
 
       {{ link(link_title, link_url, link_attributes) }}


### PR DESCRIPTION
# [UHF-8728](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8728)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added missing class for group navigation title link on sidebar navigation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8728_group_sidebar_navigation_layout_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to any group page that has the sidebar navigation present - for example this https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/helsingin-kuvataidelukio/opiskelu and make sure the sidebar navigation title doesn't look broken anymore. You can check the same page from production to see what the broken layout is like. 
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8728]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ