### PR TITLE
UHF-8740: Fix issue with broken/missing handler in group news views

### DIFF
--- a/conf/cmi/views.view.group_news_archive.yml
+++ b/conf/cmi/views.view.group_news_archive.yml
@@ -131,7 +131,7 @@ display:
       arguments:
         gid:
           id: gid
-          table: group_content_field_data
+          table: group_relationship_field_data
           field: gid
           relationship: group_content
           group_type: group
@@ -159,15 +159,11 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: true
+          specify_validation: false
           validate:
-            type: 'entity:group'
+            type: none
             fail: 'not found'
-          validate_options:
-            bundles: {  }
-            access: false
-            operation: view
-            multiple: 0
+          validate_options: {  }
           break_phrase: false
           not: false
       filters:

--- a/conf/cmi/views.view.latest_group_news.yml
+++ b/conf/cmi/views.view.latest_group_news.yml
@@ -115,7 +115,7 @@ display:
       arguments:
         gid:
           id: gid
-          table: group_content_field_data
+          table: group_relationship_field_data
           field: gid
           relationship: group_content
           group_type: group
@@ -143,15 +143,11 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: true
+          specify_validation: false
           validate:
-            type: 'entity:group'
+            type: none
             fail: 'not found'
-          validate_options:
-            bundles: {  }
-            access: false
-            operation: view
-            multiple: 0
+          validate_options: {  }
           break_phrase: false
           not: false
       filters:


### PR DESCRIPTION
# [UHF-8740](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8740)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* News listing for high schools views had broken/missing handler and the views listed all news instead of the news that belong to the group. Fixed the handler to make the listings work correctly again.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8740_high_school_news_bug_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio for example and scroll down until you can see the news listing block. It should contain only news from Alppilan lukio.
* [x] Now go to https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio/alppilan-lukion-uutiset and check that the listing contains only news for Alppilan lukio.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-8740]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ