### PR TITLE
UHF-8802: Non-linguistic URLs

### DIFF
--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -6,3 +6,4 @@ prefixes:
   fi: kasvatus-ja-koulutus
   sv: fostran-och-utbildning
   ru: childhood-and-education
+  zxx: childhood-and-education

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -7,4 +7,5 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'staging-kasvatus-ja-koulutus',
   'sv' => 'staging-fostran-och-utbildning',
   'ru' => 'staging-childhood-and-education',
+  'zxx' => 'staging-childhood-and-education',
 ];

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -7,6 +7,7 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'test-kasvatus-ja-koulutus',
   'sv' => 'test-fostran-och-utbildning',
   'ru' => 'test-childhood-and-education',
+  'zxx' => 'test-childhood-and-education',
 ];
 
 $config['helfi_global_announcement.settings']['source_environment'] = 'test';


### PR DESCRIPTION
# [UHF-8802](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802)
<!-- What problem does this solve? -->

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8802`
* Run `drush updb` and `drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure sitemap.xml works through `/childhood-and-education/sitemap.xml` and the page does not perform any redirects


[UHF-8802]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ