### PR TITLE
UHF-8926

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3872,17 +3872,17 @@
         },
         {
             "name": "drupal/group",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/group.git",
-                "reference": "2.1.0"
+                "reference": "2.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/group-2.1.0.zip",
-                "reference": "2.1.0",
-                "shasum": "d1cfc7d06b44b776f77629d3c0657617d713dd97"
+                "url": "https://ftp.drupal.org/files/projects/group-2.2.0.zip",
+                "reference": "2.2.0",
+                "shasum": "98d1844cb451d64c14004f20c492a17dc55c3332"
             },
             "require": {
                 "drupal/core": "^9.5 || ^10",
@@ -3892,8 +3892,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.0",
-                    "datestamp": "1685092674",
+                    "version": "2.2.0",
+                    "datestamp": "1692969152",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/public/modules/custom/helfi_group/README.md
+++ b/public/modules/custom/helfi_group/README.md
@@ -1,0 +1,8 @@
+## Group-navigation changes
+
+This instance has some navigation changes that differs from main navigation.
+
+### Node - published in main navigation
+
+Nodes that are published in group's navigation, the "published in main navigation" button is set to follow the node's
+translation status. This allows the school editors to handle the menu translations in simpler way.

--- a/public/modules/custom/helfi_group/helfi_group.install
+++ b/public/modules/custom/helfi_group/helfi_group.install
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains installation functions for Kasko instance.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Url;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\Entity\Node;
+
+function helfi_group_update_9001() {
+  $menu_name_prefix = 'group_menu_link_content-';
+
+  $query = \Drupal::entityQuery('menu_link_content')
+    //->condition('link.uri', 'entity:node/' . $node->id())
+    ->condition('menu_name', $menu_name_prefix, 'CONTAINS')
+    ->sort('id', 'ASC')
+    ->accessCheck(false);
+  $result = $query->execute();
+  if (!$result) {
+    return;
+  }
+
+  $menu_items = MenuLinkContent::loadMultiple(array_values($result));
+  $languages = ['fi', 'en', 'sv'];
+
+  foreach ($menu_items as $menu_item) {
+    $params = Url::fromUri($menu_item->get('link')->uri)->getRouteParameters();
+    $node_id = $params['node'];
+    foreach ($languages as $langcode) {
+      if ($menu_item->hasTranslation($langcode)) {
+        $menu_item = $menu_item->getTranslation($langcode);
+        $node = Node::load($node_id);
+        if ($node->hasTranslation($langcode)) {
+          $node = $node->getTranslation($langcode);
+          if ((bool) $menu_item->content_translation_status->value != (bool) $node->isPublished()) {
+            $menu_item->set('content_translation_status', $node->isPublished())->save();
+          }
+        }
+      }
+    }
+  }
+}

--- a/public/modules/custom/helfi_group/helfi_group.install
+++ b/public/modules/custom/helfi_group/helfi_group.install
@@ -14,7 +14,7 @@ use Drupal\node\Entity\Node;
 /**
  * Update group menu item's content translation status to match node's status.
  */
-function helfi_group_update_9001() {
+function helfi_group_update_9001(): void {
   $menu_name_prefix = 'group_menu_link_content-';
 
   $query = \Drupal::entityQuery('menu_link_content')
@@ -44,7 +44,7 @@ function helfi_group_update_9001() {
       }
 
       $node = $node->getTranslation($langcode);
-      if ((bool) $menu_item->content_translation_status->value != (bool) $node->isPublished()) {
+      if ((bool) $menu_item->content_translation_status->value !== $node->isPublished()) {
         $menu_item->set('content_translation_status', $node->isPublished())->save();
       }
 

--- a/public/modules/custom/helfi_group/helfi_group.install
+++ b/public/modules/custom/helfi_group/helfi_group.install
@@ -33,16 +33,21 @@ function helfi_group_update_9001() {
     $params = Url::fromUri($menu_item->get('link')->uri)->getRouteParameters();
     $node_id = $params['node'];
     foreach ($languages as $langcode) {
-      if ($menu_item->hasTranslation($langcode)) {
-        $menu_item = $menu_item->getTranslation($langcode);
-        $node = Node::load($node_id);
-        if ($node->hasTranslation($langcode)) {
-          $node = $node->getTranslation($langcode);
-          if ((bool) $menu_item->content_translation_status->value != (bool) $node->isPublished()) {
-            $menu_item->set('content_translation_status', $node->isPublished())->save();
-          }
-        }
+      if (!$menu_item->hasTranslation($langcode)) {
+        continue;
       }
+      
+      $menu_item = $menu_item->getTranslation($langcode);
+      $node = Node::load($node_id);
+      if (!$node->hasTranslation($langcode)) {
+        continue;
+      }
+
+      $node = $node->getTranslation($langcode);
+      if ((bool) $menu_item->content_translation_status->value != (bool) $node->isPublished()) {
+        $menu_item->set('content_translation_status', $node->isPublished())->save();
+      }
+
     }
   }
 }

--- a/public/modules/custom/helfi_group/helfi_group.install
+++ b/public/modules/custom/helfi_group/helfi_group.install
@@ -36,7 +36,7 @@ function helfi_group_update_9001() {
       if (!$menu_item->hasTranslation($langcode)) {
         continue;
       }
-      
+
       $menu_item = $menu_item->getTranslation($langcode);
       $node = Node::load($node_id);
       if (!$node->hasTranslation($langcode)) {

--- a/public/modules/custom/helfi_group/helfi_group.install
+++ b/public/modules/custom/helfi_group/helfi_group.install
@@ -11,14 +11,16 @@ use Drupal\Core\Url;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 
+/**
+ * Update group menu item's content translation status to match node's status.
+ */
 function helfi_group_update_9001() {
   $menu_name_prefix = 'group_menu_link_content-';
 
   $query = \Drupal::entityQuery('menu_link_content')
-    //->condition('link.uri', 'entity:node/' . $node->id())
     ->condition('menu_name', $menu_name_prefix, 'CONTAINS')
     ->sort('id', 'ASC')
-    ->accessCheck(false);
+    ->accessCheck(FALSE);
   $result = $query->execute();
   if (!$result) {
     return;

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -196,7 +196,7 @@ function helfi_group_form_node_form_alter(
   array &$form,
   FormStateInterface $form_state
 ): void {
-  $form['actions']['submit']['#submit'][] = 'helfi_group_set_content_translation_status';
+  $form['actions']['submit']['#submit'][] = 'helfi_group_menuitem_set_content_translation_status';
 
   if ($form['menu']) {
     $menu_parent = $form['menu']['link']['menu_parent']['#default_value'];
@@ -227,7 +227,7 @@ function helfi_group_form_node_form_alter(
 }
 
 /**
- * Ticket #UHF-8926: submit handler to set menu's translation status.
+ * Ticket #UHF-8926: submit handler to set menu items translation status.
  *
  * @param array $form
  *   The form.
@@ -236,7 +236,7 @@ function helfi_group_form_node_form_alter(
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function helfi_group_set_content_translation_status(
+function helfi_group_menuitem_set_content_translation_status(
   array &$form,
   FormStateInterface $form_state
 ) : void {
@@ -250,8 +250,8 @@ function helfi_group_set_content_translation_status(
 
     if ($link->hasTranslation($langCode)) {
       $link = $link->getTranslation($langCode);
+      $link->set('content_translation_status', $form_state->getValue('status')['value'])
+        ->save();
     }
-    $link->set('content_translation_status', $form_state->getValue('status')['value'])
-      ->save();
   }
 }

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -216,14 +216,23 @@ function helfi_group_form_node_form_alter(
       return;
     }
 
+    $current_language = $form_state
+      ->getFormObject()
+      ->getEntity()
+      ->language()
+      ->getId();
+
     $menu_link_content_id = reset($result);
     $menu_link_content = MenuLinkContent::load($menu_link_content_id);
-    if (!$menu_link_content) {
+    if (!$menu_link_content || !$menu_link_content->hasTranslation($current_language)) {
       return;
     }
 
+    $menu_link_content = $menu_link_content->getTranslation($current_language);
     $status = $menu_link_content->get('content_translation_status')->value;
     $form['menu']['content_translation_status']['#default_value'] = $status;
+    $form["menu"]["content_translation_status"]["#description"] = t('Tämä arvo muuttuu automaattisesti tallentaessa sisällön julkaisutilan mukaan.');
+
   }
 
 }
@@ -246,7 +255,7 @@ function helfi_group_menuitem_set_content_translation_status(
   $node = $form_state->getFormObject()->getEntity();
   $langCode = $node->language()->getId();
   if (
-    !empty($values['entity_id']) ||
+    empty($values['entity_id']) ||
     !$link = MenuLinkContent::load($values['entity_id'])
   ) {
     return;

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -15,6 +15,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\helfi_group\UnitFormAlter;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -173,4 +174,85 @@ function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterfac
   $form['menu_parent']['#type'] = 'hidden';
   $menu_parent = sprintf('%s:%s', $menu_name, $entity->get('parent')->value);
   $form['menu_parent']['#value'] = $menu_parent;
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * #UHF-8926 the form alter must be run after group content menu's alter.
+ */
+function helfi_group_module_implements_alter(&$implementations, $hook) : void {
+  if ($hook === 'form_alter' && isset($implementations['helfi_group'])) {
+    $group = $implementations['helfi_group'];
+    unset($implementations['helfi_group']);
+    $implementations['helfi_group'] = $group;
+  }
+}
+
+/**
+ * Implements hook_form_node_form_alter().
+ */
+function helfi_group_form_node_form_alter(
+  array &$form,
+  FormStateInterface $form_state
+): void {
+  $form['actions']['submit']['#submit'][] = 'helfi_group_set_content_translation_status';
+
+  if ($form['menu']) {
+    $menu_parent = $form['menu']['link']['menu_parent']['#default_value'];
+    $menu_name = explode(':', $menu_parent)[0];
+
+    $result = \Drupal::entityQuery('menu_link_content')
+      ->condition('link.uri', "entity:node/{$form_state->getFormObject()->getEntity()->id()}")
+      ->condition('menu_name', [$menu_name], 'IN')
+      ->sort('id', 'ASC')
+      ->accessCheck(false)
+      ->range(0, 1)
+      ->execute();
+
+    if (!$result) {
+      return;
+    }
+
+    $menu_link_content_id = reset($result);
+    $menu_link_content = MenuLinkContent::load($menu_link_content_id);
+    if (!$menu_link_content) {
+      return;
+    }
+
+    $status = $menu_link_content->get('content_translation_status')->value;
+    $form['menu']['content_translation_status']['#default_value'] = $status;
+  }
+
+}
+
+/**
+ * #UHF-8926 menu item's translation status follows node's translation status.
+ *
+ * @param array $form
+ *   The form.
+ * @param FormStateInterface $form_state
+ *   The form state.
+ * @return void
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function helfi_group_set_content_translation_status(
+  array &$form,
+  FormStateInterface $form_state
+) : void {
+  $values = $form_state->getValue('menu');
+  $node = $form_state->getFormObject()->getEntity();
+  $langCode = $node->language()->getId();
+  if (!empty($values['entity_id'])) {
+    if (!$link = MenuLinkContent::load($values['entity_id'])) {
+      return;
+    }
+
+    if ($link->hasTranslation($langCode)) {
+      $link = $link->getTranslation($langCode);
+    }
+    $link->set('content_translation_status', $form_state->getValue('status')['value'])
+      ->save();
+  }
 }

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -160,7 +160,6 @@ function helfi_group_node_create_access(AccountInterface $account, array $contex
  *
  * #UHF-8926 Group menu emits menu parent from entity's translation form.
  * Make sure menu_parent is always set.
- *
  */
 function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterface $form_state) {
   $entity = $form_state->getFormObject()->getEntity();
@@ -183,7 +182,6 @@ function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterfac
  *
  * #UHF-8926 the form alter must be run after group content menu's alter.
  * Otherwise the changes made in "menu"-render array would be overridden.
- *
  */
 function helfi_group_module_implements_alter(&$implementations, $hook) : void {
   if ($hook === 'form_alter' && isset($implementations['helfi_group'])) {

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -204,6 +204,10 @@ function helfi_group_form_node_form_alter(
     $menu_parent = $form['menu']['link']['menu_parent']['#default_value'];
     $menu_name = explode(':', $menu_parent)[0];
 
+    if (!str_contains($menu_name, 'group')) {
+      return;
+    }
+
     $result = \Drupal::entityQuery('menu_link_content')
       ->condition('link.uri', "entity:node/{$form_state->getFormObject()->getEntity()->id()}")
       ->condition('menu_name', [$menu_name], 'IN')
@@ -250,12 +254,16 @@ function helfi_group_menuitem_set_content_translation_status(
   array &$form,
   FormStateInterface $form_state
 ) : void {
+  $menu_parent = $form['menu']['link']['menu_parent']['#default_value'];
+  $menu_name = explode(':', $menu_parent)[0];
   $values = $form_state->getValue('menu');
   $node = $form_state->getFormObject()->getEntity();
   $langCode = $node->language()->getId();
+  $link = MenuLinkContent::load($values['entity_id']);
   if (
     empty($values['entity_id']) ||
-    !$link = MenuLinkContent::load($values['entity_id'])
+    !$link ||
+    !str_contains($menu_name, 'group')
   ) {
     return;
   }

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -158,15 +158,17 @@ function helfi_group_node_create_access(AccountInterface $account, array $contex
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  *
- * #UHF-8926 Prevent group's MenuContentLink's translation form from crashing
- * while saving. Crash was caused by missing menu_parent.
+ * #UHF-8926 Group menu emits menu parent from entity's translation form.
+ * Make sure menu_parent is always set.
+ *
  */
 function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterface $form_state) {
   $entity = $form_state->getFormObject()->getEntity();
   $menu_name = $entity->get('menu_name')->value;
   if (
     !$menu_name ||
-    !str_contains($menu_name, 'group')
+    !str_contains($menu_name, 'group') ||
+    !isset($form['menu_parent'])
   ) {
     return;
   }
@@ -180,6 +182,8 @@ function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterfac
  * Implements hook_module_implements_alter().
  *
  * #UHF-8926 the form alter must be run after group content menu's alter.
+ * Otherwise the changes made in "menu"-render array would be overridden.
+ *
  */
 function helfi_group_module_implements_alter(&$implementations, $hook) : void {
   if ($hook === 'form_alter' && isset($implementations['helfi_group'])) {
@@ -227,7 +231,7 @@ function helfi_group_form_node_form_alter(
 }
 
 /**
- * Ticket #UHF-8926: submit handler to set menu items translation status.
+ * Submit handler to set menu items translation status.
  *
  * @param array $form
  *   The form.
@@ -243,15 +247,15 @@ function helfi_group_menuitem_set_content_translation_status(
   $values = $form_state->getValue('menu');
   $node = $form_state->getFormObject()->getEntity();
   $langCode = $node->language()->getId();
-  if (!empty($values['entity_id'])) {
-    if (!$link = MenuLinkContent::load($values['entity_id'])) {
-      return;
-    }
-
-    if ($link->hasTranslation($langCode)) {
-      $link = $link->getTranslation($langCode);
-      $link->set('content_translation_status', $form_state->getValue('status')['value'])
-        ->save();
-    }
+  if (
+    !empty($values['entity_id']) ||
+    !$link = MenuLinkContent::load($values['entity_id'])
+  ) {
+    return;
+  }
+  if ($link->hasTranslation($langCode)) {
+    $link = $link->getTranslation($langCode);
+    $link->set('content_translation_status', $form_state->getValue('status')['value'])
+      ->save();
   }
 }

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -206,7 +206,7 @@ function helfi_group_form_node_form_alter(
       ->condition('link.uri', "entity:node/{$form_state->getFormObject()->getEntity()->id()}")
       ->condition('menu_name', [$menu_name], 'IN')
       ->sort('id', 'ASC')
-      ->accessCheck(false)
+      ->accessCheck(FALSE)
       ->range(0, 1)
       ->execute();
 
@@ -227,13 +227,12 @@ function helfi_group_form_node_form_alter(
 }
 
 /**
- * #UHF-8926 menu item's translation status follows node's translation status.
+ * Ticket #UHF-8926: submit handler to set menu's translation status.
  *
  * @param array $form
  *   The form.
- * @param FormStateInterface $form_state
+ * @param Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
- * @return void
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -153,3 +153,24 @@ function helfi_group_node_create_access(AccountInterface $account, array $contex
     ? AccessResult::allowed()
     : AccessResult::neutral();
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ *
+ * #UHF-8926 Prevent group's MenuContentLink's translation form from crashing
+ * while saving. Crash was caused by missing menu_parent.
+ */
+function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterface $form_state) {
+  $entity = $form_state->getFormObject()->getEntity();
+  $menu_name = $entity->get('menu_name')->value;
+  if (
+    !$menu_name ||
+    !str_contains($menu_name, 'group')
+  ) {
+    return;
+  }
+
+  $form['menu_parent']['#type'] = 'hidden';
+  $menu_parent = sprintf('%s:%s', $menu_name, $entity->get('parent')->value);
+  $form['menu_parent']['#value'] = $menu_parent;
+}

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -232,7 +232,6 @@ function helfi_group_form_node_form_alter(
     $status = $menu_link_content->get('content_translation_status')->value;
     $form['menu']['content_translation_status']['#default_value'] = $status;
     $form["menu"]["content_translation_status"]["#description"] = t('Tämä arvo muuttuu automaattisesti tallentaessa sisällön julkaisutilan mukaan.');
-
   }
 
 }

--- a/public/modules/custom/helfi_group/helfi_group.module
+++ b/public/modules/custom/helfi_group/helfi_group.module
@@ -167,7 +167,7 @@ function helfi_group_form_menu_link_content_form_alter(&$form, FormStateInterfac
   if (
     !$menu_name ||
     !str_contains($menu_name, 'group') ||
-    !isset($form['menu_parent'])
+    isset($form['menu_parent'])
   ) {
     return;
   }


### PR DESCRIPTION
# [UHF-8926](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

-Prevent white screen while editing group menu item translation
-Node's edit pages "published on main navigation" checkbox now updates based on group's menu content item's content translation status


## What was done
Updated group module
Fixed white screen.
Form alter to keep the "content translation status" checkbox on correct state. For group content, the "published in main navigation" state follows the node's published state. Value is updated while saving (not with javascript)
Update hook to update group's menu item's content translation status to match node status.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8926`
  * `composer require drupal/helfi_navigation:dev-UHF-8926`
  * `make fresh`
* Run `make drush-cr`

## How to test
Log in as user which is assigned to a group, for example user 19.
- Go to any group, [go to the group's menu](https://helfi-kasko.docker.so/en/childhood-and-education/group/1/menu/1/edit?destination=/fi/kasvatus-ja-koulutus/group/1/menus&group_content_menu_type=kasko_group_menu) and try to translate any menu item. The edit form for menu item should load without crash
- Go to any node which is on the group's menu
  - The "published in main navigation" button should be in correct position when node edit form is loaded (matches menu translation state)
  - Updating node's "published in main navigation" should change the group menu item's translation status.
  - Creating and translating a node and adding it to a group should work normally
- Compare couple of the group menus as incognito user with production menu. It should look the same

* [x] Check that this feature works
* [ ] Check that code follows our standards

## Other PRs:

* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/47

[UHF-8926]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ