### PR TITLE
UHF-9113: fix override_node_options settings

### DIFF
--- a/conf/cmi/override_node_options.settings.yml
+++ b/conf/cmi/override_node_options.settings.yml
@@ -1,0 +1,2 @@
+general_permissions: 0
+specific_permissions: 1


### PR DESCRIPTION
# [UHF-9113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix settings for override_node_options module.

This change is required so we can update to Drupal 10. `school_editor` role has permissions: 
```
override landing_page published option
override news_item published option
override page published option
```
that do not exists unless override_node_options is configuration file exists. Drupal 10 requires that all assigned permissions must exist.

This was introduced in https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/255.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-fix-override_node_options-settings`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] As an admin, go to [`/admin/people/permissions`](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/admin/people/permissions) and verify that Override node options permissions exist.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* City-of-Helsinki/drupal-hdbt/pull/800
* City-of-Helsinki/drupal-helfi-platform-config/pull/617



[UHF-9113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ