### PR TITLE
UHF-9236: add comprehensive school editor permission to edit tpr unit

### DIFF
--- a/conf/cmi/user.role.comprehensive_school_editor.yml
+++ b/conf/cmi/user.role.comprehensive_school_editor.yml
@@ -57,6 +57,7 @@ permissions:
   - 'mark as hidden in editoria11y'
   - 'schedule publishing of nodes'
   - 'translate editable entities'
+  - 'update any tpr_unit'
   - 'update media'
   - 'use text format full_html'
   - 'use text format minimal'


### PR DESCRIPTION
# [UHF-9236](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9236)
Added permission

## What was done
Added permission

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9236`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Log in as user with comprehensive school editor permission (uid=550 for example)
- Go to tpr unit listing
- You should have permission to edit the tpr units


* [x] Check that this feature works



[UHF-9236]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ