### PR TITLE
UHF-9159: Subgroup field display configs.

### DIFF
--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -359,6 +359,16 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  subgroup:
+    type: readonly_field_widget
+    weight: 40
+    region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   toc_enabled:
     type: boolean_checkbox
     weight: 3
@@ -415,4 +425,3 @@ hidden:
   field_study_field: true
   hide_description: true
   ontologyword_ids: true
-  show_www: true

--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -425,3 +425,4 @@ hidden:
   field_study_field: true
   hide_description: true
   ontologyword_ids: true
+  show_www: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -35,7 +35,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 14
+    weight: 16
     region: content
   accessibility_phone:
     type: string
@@ -43,14 +43,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 13
+    weight: 15
     region: content
   accessibility_sentences:
     type: tpr_accessibility_sentence
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 21
+    weight: 23
     region: content
   accessibility_www:
     type: link
@@ -62,14 +62,14 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 15
+    weight: 17
     region: content
   address:
     type: address_plain
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   address_postal:
     type: string
@@ -77,21 +77,21 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 9
+    weight: 11
     region: content
   call_charge_info:
     type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 11
+    weight: 13
     region: content
   contacts:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 26
+    weight: 30
     region: content
   description:
     type: text_default
@@ -106,7 +106,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 8
+    weight: 10
     region: content
   field_content:
     type: entity_reference_revisions_entity_view
@@ -115,7 +115,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 20
+    weight: 22
     region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
@@ -124,21 +124,21 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 22
+    weight: 24
     region: content
   field_metatags:
     type: metatag_empty_formatter
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 17
+    weight: 19
     region: content
   highlights:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 23
+    weight: 27
     region: content
   latitude:
     type: string
@@ -146,14 +146,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 24
+    weight: 28
     region: content
   links:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 25
+    weight: 29
     region: content
   longitude:
     type: string
@@ -161,7 +161,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 23
+    weight: 25
     region: content
   name:
     type: string
@@ -184,14 +184,14 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 7
+    weight: 9
     region: content
   other_info:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 18
+    weight: 20
     region: content
   phone:
     type: telephone_link
@@ -199,7 +199,7 @@ content:
     settings:
       title: ''
     third_party_settings: {  }
-    weight: 6
+    weight: 8
     region: content
   picture_url:
     type: imagecache_external_responsive_image
@@ -208,7 +208,7 @@ content:
       imagecache_external_link: ''
       imagecache_external_responsive_style: image__3_2
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   picture_url_override:
     type: entity_reference_entity_view
@@ -217,14 +217,14 @@ content:
       view_mode: image
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   price_info:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 19
+    weight: 21
     region: content
   provided_languages:
     type: string
@@ -232,7 +232,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 23
+    weight: 26
     region: content
   service_map_embed:
     type: service_map_embed
@@ -242,7 +242,7 @@ content:
       link_title: 'Open larger map'
       target: true
     third_party_settings: {  }
-    weight: 10
+    weight: 12
     region: content
   services:
     type: entity_reference_label
@@ -250,7 +250,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 16
+    weight: 18
+    region: content
+  subgroup:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 32
     region: content
   toc_enabled:
     type: boolean
@@ -260,21 +267,21 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   topical:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 27
+    weight: 31
     region: content
   unit_picture_caption:
     type: basic_string
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 7
     region: content
   www:
     type: link
@@ -286,7 +293,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 14
     region: content
 hidden:
   created: true


### PR DESCRIPTION
# [UHF-9159](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159)
<!-- What problem does this solve? -->
Kasko needs own form and view display configs for the TPR unit.

## What was done
<!-- Describe what was done -->

* Show subgroup field in form and view.

## How to install

* Follow the instructions in https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/161

## How to test
* The subgroup field should be visible in the TPR unit pages and the edit pages on KASKO instance.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/161


[UHF-9159]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ