### PR TITLE
UHF-9132: Add max-width limitation to all content types without sidebar except landing page

### DIFF
--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -110,7 +110,14 @@ function helfi_kasko_content_preprocess_block(&$variables) {
 
   // Check if the content field first paragraph is High school search
   // and add classes accordingly.
-  if ($paragraph->getType() === 'high_school_search') {
+  if (
+    $paragraph->getType() === 'after_school_activity_search' ||
+    $paragraph->getType() === 'daycare_search' ||
+    $paragraph->getType() === 'high_school_search' ||
+    $paragraph->getType() === 'playground_search' ||
+    $paragraph->getType() === 'school_search' ||
+    $paragraph->getType() === 'vocational_school_search'
+  ) {
     $first_paragraph_gray = 'has-first-gray-bg-block';
 
     // If lead_in field has value, unset 1st gray paragraph class.

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -116,7 +116,7 @@ function helfi_kasko_content_preprocess_block(&$variables) {
     'high_school_search',
     'playground_search',
     'school_search',
-    'vocational_school_search'
+    'vocational_school_search',
   ];
 
   if (in_array($paragraph->getType(), $paragraph_types)) {

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -108,16 +108,18 @@ function helfi_kasko_content_preprocess_block(&$variables) {
   }
   $first_paragraph_gray = &$variables['content']['hero_block']['#first_paragraph_grey'];
 
-  // Check if the content field first paragraph is High school search
+  // Check if the content field first paragraph is unit search clone
   // and add classes accordingly.
-  if (
-    $paragraph->getType() === 'after_school_activity_search' ||
-    $paragraph->getType() === 'daycare_search' ||
-    $paragraph->getType() === 'high_school_search' ||
-    $paragraph->getType() === 'playground_search' ||
-    $paragraph->getType() === 'school_search' ||
-    $paragraph->getType() === 'vocational_school_search'
-  ) {
+  $paragraph_types = [
+    'after_school_activity_search',
+    'daycare_search',
+    'high_school_search',
+    'playground_search',
+    'school_search',
+    'vocational_school_search'
+  ];
+
+  if (in_array($paragraph->getType(), $paragraph_types)) {
     $first_paragraph_gray = 'has-first-gray-bg-block';
 
     // If lead_in field has value, unset 1st gray paragraph class.

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--after-school-activity-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--after-school-activity-search.html.twig
@@ -1,7 +1,7 @@
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
-      component_classes: [ 'component--unit-search' ],
+      component_classes: [ 'component--full-width', 'component--unit-search' ],
       component_title: content.field_after_school_search_title,
       component_description: content.field_after_school_search_desc,
       component_content_class: 'unit-search unit-search--after-school-activity-search',

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--daycare-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--daycare-search.html.twig
@@ -1,7 +1,7 @@
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
-      component_classes: [ 'component--unit-search' ],
+      component_classes: [ 'component--full-width', 'component--unit-search' ],
       component_title: content.field_daycare_search_title,
       component_description: content.field_daycare_search_description,
       component_content_class: 'unit-search unit-search--daycare-search',

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--high-school-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--high-school-search.html.twig
@@ -1,7 +1,7 @@
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
-      component_classes: [ 'component--unit-search' ],
+      component_classes: [ 'component--full-width', 'component--unit-search' ],
       component_title: content.field_hs_search_title,
       component_description: content.field_hs_search_description,
       component_content_class: 'unit-search unit-search--high-school',

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--playground-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--playground-search.html.twig
@@ -1,7 +1,7 @@
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
-      component_classes: [ 'component--unit-search' ],
+      component_classes: [ 'component--full-width', 'component--unit-search' ],
       component_title: content.field_playground_search_title,
       component_description: content.field_playground_search_desc,
       component_content_class: 'unit-search unit-search--playground-search',

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--school-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--school-search.html.twig
@@ -2,6 +2,7 @@
   {% embed "@hdbt/misc/component.twig" with
     {
       component_classes: [
+        'component--full-width',
         'component--react-search',
         'component--react-search--schools'
       ],

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--vocational-school-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--vocational-school-search.html.twig
@@ -1,7 +1,7 @@
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
-      component_classes: [ 'component--unit-search' ],
+      component_classes: [ 'component--full-width', 'component--unit-search' ],
       component_title: content.field_vs_search_title,
       component_description: content.field_vs_search_description,
       component_content_class: 'unit-search unit-search--vocational-school',


### PR DESCRIPTION
# [UHF-9132](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9132)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* KASKO specific changes for the limit to the component--upper region of max-width 860px.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9132`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9132`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the hdbt PR.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/811
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/734
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/360
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/503

[UHF-9132]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ