### PR TITLE
UHF-9064: Event subscriber moved under helfi_react_search module.

### DIFF
--- a/public/modules/custom/helfi_kasko_content/src/EventSubscriber/KaskoElasticIndexSubscriber.php
+++ b/public/modules/custom/helfi_kasko_content/src/EventSubscriber/KaskoElasticIndexSubscriber.php
@@ -6,7 +6,6 @@ namespace Drupal\helfi_kasko_content\EventSubscriber;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\elasticsearch_connector\Event\BuildIndexParamsEvent;
-use Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent;
 use Drupal\helfi_kasko_content\SchoolUtility;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -29,30 +28,8 @@ class KaskoElasticIndexSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
-      PrepareIndexMappingEvent::PREPARE_INDEX_MAPPING => 'addCoordinatesField',
       BuildIndexParamsEvent::BUILD_PARAMS => 'modifyOntologywordDetailsFields',
     ];
-  }
-
-  /**
-   * Set mapping for unit's coordinates as geo_point field.
-   *
-   * @param \Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent $event
-   *   Event emitted by elasticsearch_connector.
-   */
-  public function addCoordinatesField(PrepareIndexMappingEvent $event): void {
-    /** @var array $params */
-    $params = $event->getIndexMappingParams();
-
-    if ($params['index'] !== 'schools') {
-      return;
-    }
-
-    $params['body']['properties']['coordinates'] = [
-      'type' => 'geo_point',
-    ];
-
-    $event->setIndexMappingParams($params);
   }
 
   /**


### PR DESCRIPTION
# [UHF-9064](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9064)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

*  Event subscriber moved under helfi_react_search module.

## How to install

Check instructions from HDBT PR: https://github.com/City-of-Helsinki/drupal-hdbt/pull/827

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/827
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/643
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/697


[UHF-9064]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ