### PR TITLE
UHF-9453: Remove Espoo and Vantaa schools from comprehensive school search fallback

### DIFF
--- a/conf/cmi/views.view.comprehensive_school_search.yml
+++ b/conf/cmi/views.view.comprehensive_school_search.yml
@@ -262,6 +262,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        address__locality:
+          id: address__locality
+          table: tpr_unit_field_data
+          field: address__locality
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: address
+          plugin_id: string
+          operator: contains
+          value: Helsinki
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:

--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -29,13 +29,16 @@
     {% set view_mode_class = 'card--vocational-school-teaser' %}
     {% set unit_url_external = false %}
   {% else %}
-    {% set view_mode_class = 'card--comprehensive-school-teaser' %}
+    {% set view_mode_class = [
+      'card--comprehensive-school-teaser',
+      not content_entity_published ? 'card--unpublished',
+    ] %}
     {% set unit_url_external = false %}
   {% endif %}
 
   {% if view_mode == 'comprehensive_school_card' %}
     {% embed '@hdbt/component/card.twig' with {
-      card_modifier_class: view_mode_class,
+      card_modifier_class: view_mode_class|join(' '),
       card_image: card_image,
       card_title: card_title,
       card_url: unit_url,


### PR DESCRIPTION
# [UHF-9453](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9453)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change comprehensive school search fallback view so that it lists only the schools that have Helsinki in their address

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9453`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Disable javascript on the https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/peruskoulut comprehensive school search page and make sure that the listing doesn't include schools from Espoo or Vantaa anymore.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-9453]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ