### PR TITLE
UHF-9458: Configure openid client scopes

### DIFF
--- a/conf/cmi/openid_connect.client.tunnistamo.yml
+++ b/conf/cmi/openid_connect.client.tunnistamo.yml
@@ -16,5 +16,5 @@ settings:
   is_production: 0
   auto_login: 0
   environment_url: 'https://tunnistamo.test.hel.ninja/openid'
-  client_scopes: ''
+  client_scopes: 'openid,email'
   client_roles: {  }


### PR DESCRIPTION
# [UHF-9458](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9458)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add `openid,email` scopes to tunnistamo client.

[UHF-9458]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ