### PR TITLE
UHF-9230: Add after_school_activity_card

### DIFF
--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.after_school_activity_card.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.after_school_activity_card.yml
@@ -1,0 +1,106 @@
+uuid: 848ab6fd-17ee-43a7-8a1d-5dbef1cd99e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.tpr_unit.after_school_activity_card
+    - field.field.tpr_unit.tpr_unit.field_categories
+    - field.field.tpr_unit.tpr_unit.field_content
+    - field.field.tpr_unit.tpr_unit.field_districts
+    - field.field.tpr_unit.tpr_unit.field_hs_front_page
+    - field.field.tpr_unit.tpr_unit.field_lower_content
+    - field.field.tpr_unit.tpr_unit.field_metatags
+    - field.field.tpr_unit.tpr_unit.field_ontologyword_details
+    - field.field.tpr_unit.tpr_unit.field_study_field
+    - field.field.tpr_unit.tpr_unit.field_unit_type
+  module:
+    - address
+    - helfi_address_search
+    - helfi_tpr
+_core:
+  default_config_hash: SoKM8cPSwNeMsP8ZRG0b8B8n-e1Uy9yoMmPk018vmoY
+id: tpr_unit.tpr_unit.after_school_activity_card
+targetEntityType: tpr_unit
+bundle: tpr_unit
+mode: after_school_activity_card
+content:
+  address:
+    type: address_plain
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  name:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  name_override:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  opening_hours:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  provided_languages:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden:
+  accessibility_email: true
+  accessibility_phone: true
+  accessibility_sentences: true
+  accessibility_www: true
+  address_postal: true
+  call_charge_info: true
+  contacts: true
+  created: true
+  description: true
+  email: true
+  enrich_description: true
+  field_categories: true
+  field_content: true
+  field_districts: true
+  field_hs_front_page: true
+  field_lower_content: true
+  field_metatags: true
+  field_ontologyword_details: true
+  field_study_field: true
+  field_unit_type: true
+  hide_description: true
+  highlights: true
+  langcode: true
+  latitude: true
+  links: true
+  longitude: true
+  other_info: true
+  phone: true
+  picture_url: true
+  picture_url_override: true
+  price_info: true
+  search_api_excerpt: true
+  service_map_embed: true
+  services: true
+  show_www: true
+  streetview_entrance_url: true
+  subgroup: true
+  toc_enabled: true
+  topical: true
+  unit_picture_caption: true
+  www: true

--- a/conf/cmi/core.entity_view_mode.tpr_unit.after_school_activity_card.yml
+++ b/conf/cmi/core.entity_view_mode.tpr_unit.after_school_activity_card.yml
@@ -1,0 +1,11 @@
+uuid: e6488cfa-a137-4c20-aba9-94297b9307fc
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_unit.after_school_activity_card
+label: 'After-school activity card'
+description: ''
+targetEntityType: tpr_unit
+cache: true

--- a/conf/cmi/views.view.after_school_activity_search.yml
+++ b/conf/cmi/views.view.after_school_activity_search.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.tpr_unit.minimal
+    - core.entity_view_mode.tpr_unit.after_school_activity_card
     - taxonomy.vocabulary.unit_type
   module:
     - better_exposed_filters
@@ -76,7 +76,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          view_mode: minimal
+          view_mode: after_school_activity_card
         distance:
           id: distance
           table: tpr_unit
@@ -461,6 +461,7 @@ display:
         - user
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.tpr_unit.tpr_unit.after_school_activity_card'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.comprehensive_school_card'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.default'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.high_school_card'
@@ -485,6 +486,7 @@ display:
         - user
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.tpr_unit.tpr_unit.after_school_activity_card'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.comprehensive_school_card'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.default'
         - 'config:core.entity_view_display.tpr_unit.tpr_unit.high_school_card'


### PR DESCRIPTION
# [UHF-9230](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9230)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add more information to after-school activity search results.
  * Add `after_school_activity_card` display mode.
  * Use `after_school_activity_card` display mode in `after_school_activity_search` view.
  * HDBT: Add new fields in template.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9230-after-school-activity-search-card`
  * `composer require drupal/hdbt:dev-UHF-9230-after-school-activity-search-card`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check [after-school activity search](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/iltapaivatoimintapaikat).

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/884

[UHF-9230]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ