### PR TITLE
UHF-9271: added exposed language filter

### DIFF
--- a/conf/cmi/language/fi/views.view.after_school_activity_search.yml
+++ b/conf/cmi/language/fi/views.view.after_school_activity_search.yml
@@ -33,6 +33,9 @@ display:
           expose:
             label: Osoite
             description: 'Kirjoita kadunnimi ja talonumero'
+        tpr_provided_languages:
+          expose:
+            label: 'Valitse toimintakieli'
       header:
         area_address_search_info:
           succeed:

--- a/conf/cmi/language/sv/views.view.after_school_activity_search.yml
+++ b/conf/cmi/language/sv/views.view.after_school_activity_search.yml
@@ -30,6 +30,9 @@ display:
           expose:
             label: Adress
             description: 'Ange gatunamnet och husnumret'
+        tpr_provided_languages:
+          expose:
+            label: 'Välj verksamhetsspråk'
       header:
         area_address_search_info:
           succeed:

--- a/conf/cmi/views.view.after_school_activity_search.yml
+++ b/conf/cmi/views.view.after_school_activity_search.yml
@@ -180,6 +180,17 @@ display:
                     filter_rewrite_values: ''
                   collapsible: false
                   is_secondary: false
+              tpr_provided_languages:
+                plugin_id: bef
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: false
       access:
         type: perm
         options:
@@ -385,6 +396,59 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        tpr_provided_languages:
+          id: tpr_provided_languages
+          table: tpr_unit__provided_languages
+          field: tpr_provided_languages
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          plugin_id: tpr_provided_languages
+          operator: in
+          value:
+            fi: fi
+            sv: sv
+          group: 1
+          exposed: true
+          expose:
+            operator_id: tpr_provided_languages_op
+            label: 'Select the operating language'
+            description: ''
+            use_operator: false
+            operator: tpr_provided_languages_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: languages
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              daycare_editor: '0'
+              playground_editor: '0'
+              comprehensive_school_editor: '0'
+              school_editor: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              debug_api: '0'
+              super_administrator: '0'
+            reduce: true
           is_grouped: false
           group_info:
             label: ''


### PR DESCRIPTION
# [UHF-9271](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9271)
Added FI and sv language filters to search view.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9271`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Go to [/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/iltapaivatoimintapaikat](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/iltapaivatoimintapaikat)
- Try filtering result with the language selector
 



[UHF-9271]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ