### PR TITLE
UHF-9531: Add separate client for edu users

### DIFF
--- a/conf/cmi/openid_connect.client.keycloak.yml
+++ b/conf/cmi/openid_connect.client.keycloak.yml
@@ -15,7 +15,7 @@ settings:
   iss_allowed_domains: ''
   is_production: 0
   auto_login: 0
-  environment_url: 'https://tunnistamo.test.hel.ninja/openid'
+  environment_url: ''
   client_scopes: 'openid,email'
   client_roles: {  }
 

--- a/conf/cmi/openid_connect.client.keycloak.yml
+++ b/conf/cmi/openid_connect.client.keycloak.yml
@@ -1,4 +1,4 @@
-uuid: 9ffec99b-43ed-43f9-9cab-df2808a404a3
+uuid: 734bd97e-6964-42d0-80ad-2b641885ae6b
 langcode: en
 status: true
 dependencies:
@@ -6,8 +6,8 @@ dependencies:
     - helfi_tunnistamo
 _core:
   default_config_hash: nGpk9fP8YMhP_c3Sz_aCQFVhAJyN6eJI6E4Qpnqna-A
-id: tunnistamo
-label: edu.hel.fi
+id: keycloak
+label: Tunnistamo
 plugin: tunnistamo
 settings:
   client_id: placeholder
@@ -18,3 +18,4 @@ settings:
   environment_url: 'https://tunnistamo.test.hel.ninja/openid'
   client_scopes: 'openid,email'
   client_roles: {  }
+

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -13,6 +13,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -335,4 +336,20 @@ function helfi_kasko_content_views_data_alter(array &$data) {
       'id' => 'study_programme_type_filter',
     ],
   ];
+}
+
+/**
+ * Implements hook_openid_connect_pre_authorize().
+ */
+function helfi_kasko_content_openid_connect_pre_authorize(UserInterface|bool $account, array $context) : bool {
+  $pluginId = $context['plugin_id'];
+  $userinfo = $context['userinfo'] ?? NULL;
+  $email = $userinfo['email'] ?? NULL;
+
+  return match ($pluginId) {
+    // @todo remove when edu.hel.fi clients work with tunnistamo.
+    'tunnistamo' => $email === helfi_tunnistamo_create_email($userinfo),
+    'keycloak' => $email !== helfi_tunnistamo_create_email($userinfo),
+    default => TRUE,
+  };
 }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\ParagraphInterface;
@@ -346,10 +347,21 @@ function helfi_kasko_content_openid_connect_pre_authorize(UserInterface|bool $ac
   $userinfo = $context['userinfo'] ?? NULL;
   $email = $userinfo['email'] ?? NULL;
 
-  return match ($pluginId) {
-    // @todo remove when edu.hel.fi clients work with tunnistamo.
+  // Helsinki-profiili has issues with edu.hel.fi users:
+  // https://helsinkisolutionoffice.atlassian.net/browse/HP-2147.
+  // As a workaround, kasko has a separate client that still uses old
+  // Tunnistamo. This prevents non edu.hel.fi users from using tunnistamo.
+  // @todo remove when edu.hel.fi clients work with Helsinki-profiili.
+  $allowLogin = match ($pluginId) {
     'tunnistamo' => $email === helfi_tunnistamo_create_email($userinfo),
     'keycloak' => $email !== helfi_tunnistamo_create_email($userinfo),
     default => TRUE,
   };
+
+  if (!$allowLogin && $pluginId === 'tunnistamo') {
+    \Drupal::messenger()
+      ->addError(new TranslatableMarkup("Only edu.hel.fi users are allowed to log in with this method."));
+  }
+
+  return $allowLogin;
 }

--- a/public/modules/custom/helfi_kasko_content/translations/fi.po
+++ b/public/modules/custom/helfi_kasko_content/translations/fi.po
@@ -177,3 +177,6 @@ msgstr "B2-kieli"
 msgctxt "TPR Ontologyword details schools"
 msgid "Language offering"
 msgstr "Kielitarjonta"
+
+msgid "Only edu.hel.fi users are allowed to log in with this method"
+msgstr "Vain edu.hel.fi käyttäjät voivat kirjautua tällä kirjautumistavalla."

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -36,3 +36,6 @@ $config['react_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT'
 // @todo remove separate client once edu.hel.fi users work with keycloak.
 $config['openid_connect.client.keycloak']['settings']['client_id'] = getenv('KEYCLOAK_CLIENT_ID');
 $config['openid_connect.client.keycloak']['settings']['client_secret'] = getenv('KEYCLOAK_CLIENT_SECRET');
+if ($keycloak_environment_url = getenv('KEYCLOAK_ENVIRONMENT_URL')) {
+  $config['openid_connect.client.keycloak']['settings']['environment_url'] = $keycloak_environment_url;
+}

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -32,3 +32,7 @@ $config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_U
 
 // Sentry DSN for React.
 $config['react_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT');
+
+// @todo remove separate client once edu.hel.fi users work with keycloak.
+$config['openid_connect.client.keycloak']['settings']['client_id'] = getenv('KEYCLOAK_CLIENT_ID');
+$config['openid_connect.client.keycloak']['settings']['client_secret'] = getenv('KEYCLOAK_CLIENT_SECRET');


### PR DESCRIPTION
# [UHF-9531](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9531)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add separate client for edu users so we can migrate to keycloak for all other users.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9531-separate-client-for-edu`
  * `make fresh`
* Run `make drush-cr`
* Add `TUNNISTAMO_CLIENT_ID`, `TUNNISTAMO_CLIENT_ID`, `KEYCLOAK_CLIENT_ID` and `KEYCLOAK_CLIENT_SECRET` variables:
  ```php
  $config['openid_connect.client.keycloak']['settings']['client_id'] = 'AAA...';
  $config['openid_connect.client.keycloak']['settings']['client_secret'] = 'BBB...';
  $config['openid_connect.client.tunnistamo']['settings']['client_id'] = 'CCC...';
  $config['openid_connect.client.tunnistamo']['settings']['client_secret'] = 'DDD...';
  ```

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Wait until the new return url `/fi/kasvatus-ja-koulutus/openid-connect/keycloak` is activated
* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-9531]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ