### PR TITLE
Revert "Revert "UHF-9531: Add separate client for edu users""

### DIFF
--- a/conf/cmi/openid_connect.client.keycloak.yml
+++ b/conf/cmi/openid_connect.client.keycloak.yml
@@ -1,4 +1,4 @@
-uuid: 9ffec99b-43ed-43f9-9cab-df2808a404a3
+uuid: 734bd97e-6964-42d0-80ad-2b641885ae6b
 langcode: en
 status: true
 dependencies:
@@ -6,8 +6,8 @@ dependencies:
     - helfi_tunnistamo
 _core:
   default_config_hash: nGpk9fP8YMhP_c3Sz_aCQFVhAJyN6eJI6E4Qpnqna-A
-id: tunnistamo
-label: edu.hel.fi
+id: keycloak
+label: Tunnistamo
 plugin: tunnistamo
 settings:
   client_id: placeholder
@@ -15,7 +15,7 @@ settings:
   iss_allowed_domains: ''
   is_production: 0
   auto_login: 0
-  environment_url: 'https://tunnistamo.test.hel.ninja/openid'
+  environment_url: ''
   client_scopes: 'openid,email'
   client_roles: {  }
-  debug_log: false
+

--- a/conf/cmi/openid_connect.client.tunnistamo.yml
+++ b/conf/cmi/openid_connect.client.tunnistamo.yml
@@ -7,7 +7,7 @@ dependencies:
 _core:
   default_config_hash: nGpk9fP8YMhP_c3Sz_aCQFVhAJyN6eJI6E4Qpnqna-A
 id: tunnistamo
-label: edu.hel.fi
+label: Teacher sign in
 plugin: tunnistamo
 settings:
   client_id: placeholder

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -10,9 +10,11 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -335,4 +337,31 @@ function helfi_kasko_content_views_data_alter(array &$data) {
       'id' => 'study_programme_type_filter',
     ],
   ];
+}
+
+/**
+ * Implements hook_openid_connect_pre_authorize().
+ */
+function helfi_kasko_content_openid_connect_pre_authorize(UserInterface|bool $account, array $context) : bool {
+  $pluginId = $context['plugin_id'];
+  $userinfo = $context['userinfo'] ?? NULL;
+  $email = $userinfo['email'] ?? NULL;
+
+  // Helsinki-profiili has issues with edu.hel.fi users:
+  // https://helsinkisolutionoffice.atlassian.net/browse/HP-2147.
+  // As a workaround, kasko has a separate client that still uses old
+  // Tunnistamo. This prevents non edu.hel.fi users from using tunnistamo.
+  // @todo remove when edu.hel.fi clients work with Helsinki-profiili.
+  $allowLogin = match ($pluginId) {
+    'tunnistamo' => $email === helfi_tunnistamo_create_email($userinfo),
+    'keycloak' => $email !== helfi_tunnistamo_create_email($userinfo),
+    default => TRUE,
+  };
+
+  if (!$allowLogin && $pluginId === 'tunnistamo') {
+    \Drupal::messenger()
+      ->addError(new TranslatableMarkup("Only edu.hel.fi users are allowed to log in with this method."));
+  }
+
+  return $allowLogin;
 }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -360,8 +361,31 @@ function helfi_kasko_content_openid_connect_pre_authorize(UserInterface|bool $ac
 
   if (!$allowLogin && $pluginId === 'tunnistamo') {
     \Drupal::messenger()
-      ->addError(new TranslatableMarkup("Only edu.hel.fi users are allowed to log in with this method."));
+      ->addError(new TranslatableMarkup("Only teachers are allowed to log in with this method."));
   }
 
   return $allowLogin;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function helfi_kasko_content_form_openid_connect_login_form_alter(&$form, FormStateInterface $form_state) : void {
+  // UHF-9531: Add help text to teacher login button.
+  // @todo remove once separate login is no longer needed for edu users.
+  if (isset($form['openid_connect_client_tunnistamo_login'])) {
+    $build['button'] = $form['openid_connect_client_tunnistamo_login'];
+    $build['button']['#value'] = new TranslatableMarkup('Teacher sign in', [], [
+      'context' => 'Kasko teacher sign in',
+    ]);
+    $build['help'] = [
+      '#prefix' => '<p>',
+      '#suffix' => '</p>',
+      '#plain_text' => new TranslatableMarkup('Sign in like before using your Helsinki1 credentials.', [], [
+        'context' => 'Kasko teacher sign in',
+      ]),
+    ];
+
+    $form['openid_connect_client_tunnistamo_login'] = $build;
+  }
 }

--- a/public/modules/custom/helfi_kasko_content/translations/fi.po
+++ b/public/modules/custom/helfi_kasko_content/translations/fi.po
@@ -177,3 +177,6 @@ msgstr "B2-kieli"
 msgctxt "TPR Ontologyword details schools"
 msgid "Language offering"
 msgstr "Kielitarjonta"
+
+msgid "Only edu.hel.fi users are allowed to log in with this method"
+msgstr "Vain edu.hel.fi käyttäjät voivat kirjautua tällä kirjautumistavalla."

--- a/public/modules/custom/helfi_kasko_content/translations/fi.po
+++ b/public/modules/custom/helfi_kasko_content/translations/fi.po
@@ -178,5 +178,13 @@ msgctxt "TPR Ontologyword details schools"
 msgid "Language offering"
 msgstr "Kielitarjonta"
 
-msgid "Only edu.hel.fi users are allowed to log in with this method"
-msgstr "Vain edu.hel.fi käyttäjät voivat kirjautua tällä kirjautumistavalla."
+msgid "Only teachers are allowed to log in with this method"
+msgstr "Vain opettajat voivat kirjautua tällä kirjautumistavalla."
+
+msgctxt "Kasko teacher sign in"
+msgid "Teacher sign in"
+msgstr "Opettajien kirjautuminen"
+
+msgctxt "Kasko teacher sign in"
+msgid "Sign in like before using your Helsinki1 credentials."
+msgstr "Kirjaudu kuten ennenkin, mutta käytä opettajien omaa kirjautumispainiketta."

--- a/public/modules/custom/helfi_kasko_content/translations/sv.po
+++ b/public/modules/custom/helfi_kasko_content/translations/sv.po
@@ -177,3 +177,11 @@ msgstr "B2-språket"
 msgctxt "TPR Ontologyword details schools"
 msgid "Language offering"
 msgstr "Språkutbudet"
+
+msgctxt "Kasko teacher sign in"
+msgid "Teacher sign in"
+msgstr "Logga in (lärare)"
+
+msgctxt "Kasko teacher sign in"
+msgid "Sign in like before using your Helsinki1 credentials."
+msgstr "Logga in som förut med dina Helsinki1-uppgifter."

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -27,6 +27,13 @@ $config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_U
 // Sentry DSN for React.
 $config['react_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT');
 
+// @todo remove separate client once edu.hel.fi users work with keycloak (UHF-9531).
+$config['openid_connect.client.keycloak']['settings']['client_id'] = getenv('KEYCLOAK_CLIENT_ID');
+$config['openid_connect.client.keycloak']['settings']['client_secret'] = getenv('KEYCLOAK_CLIENT_SECRET');
+if ($keycloak_environment_url = getenv('KEYCLOAK_ENVIRONMENT_URL')) {
+  $config['openid_connect.client.keycloak']['settings']['environment_url'] = $keycloak_environment_url;
+}
+
 $additionalEnvVars = [
   'AZURE_BLOB_STORAGE_SAS_TOKEN|BLOBSTORAGE_SAS_TOKEN',
   'AZURE_BLOB_STORAGE_NAME',
@@ -50,7 +57,11 @@ $additionalEnvVars = [
   'ELASTIC_USER',
   'ELASTIC_PASSWORD',
   'SENTRY_DSN_REACT',
+  'KEYCLOAK_CLIENT_ID',
+  'KEYCLOAK_CLIENT_SECRET',
+  'KEYCLOAK_ENVIRONMENT_URL',
 ];
+
 foreach ($additionalEnvVars as $var) {
   $preflight_checks['environmentVariables'][] = $var;
 }

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -57,6 +57,7 @@ $additionalEnvVars = [
   'ELASTIC_USER',
   'ELASTIC_PASSWORD',
   'SENTRY_DSN_REACT',
+  // @todo remove separate client once edu.hel.fi users work with keycloak (UHF-9531).
   'KEYCLOAK_CLIENT_ID',
   'KEYCLOAK_CLIENT_SECRET',
   'KEYCLOAK_ENVIRONMENT_URL',

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -1,6 +1,5 @@
 <?php
 
-$config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/staging-kasvatus-ja-koulutus/openid-connect/tunnistamo';
 $config['helfi_proxy.settings']['asset_path'] = 'staging-kasko-assets';
 $config['helfi_proxy.settings']['prefixes'] = [
   'en' => 'staging-childhood-and-education',


### PR DESCRIPTION
# [UHF-9531](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9531)
<!-- What problem does this solve? -->

## Reverts City-of-Helsinki/drupal-helfi-kasvatus-koulutus#560

Kasko wanted more time to inform users about https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/556. Revert now that this weeks deployment is done.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout revert-560-revert-556-UHF-9531-separate-client-for-edu`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Visit https://helfi-kasko.docker.so/en/childhood-and-education/user/login
* [ ] Check that code follows our standards


[UHF-9531]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ