### PR TITLE
UHF-10169: disable ad role mapping

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -26,25 +26,6 @@ $config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_U
 
 // Sentry DSN for React.
 $config['react_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT');
-$config['openid_connect.client.tunnistamo']['settings']['ad_roles_disabled_amr'] = ['eduad'];
-$config['openid_connect.client.tunnistamo']['settings']['ad_roles'] = [
-  [
-    'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
-    'roles' => ['admin'],
-  ],
-  [
-    'ad_role' => 'Drupal_Helfi_Kasvatus_ja_koulutus_sisallontuottajat_laaja',
-    'roles' => ['editor'],
-  ],
-  [
-    'ad_role' => 'Drupal_Helfi_Kasvatus_ja_koulutus_sisallontuottajat_suppea',
-    'roles' => ['content_producer'],
-  ],
-  [
-    'ad_role' => '947058f4-697e-41bb-baf5-f69b49e5579a',
-    'roles' => ['super_administrator'],
-  ],
-];
 
 $additionalEnvVars = [
   'AZURE_BLOB_STORAGE_SAS_TOKEN|BLOBSTORAGE_SAS_TOKEN',


### PR DESCRIPTION
# [UHF-10169](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10169)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Kasko roles `comprehensive_school_editor`, `daycare_editor`, `playground_editor`, `school_editor` don't have AD role mapping. The tunnistamo module eats roles that are not configured for user on login, so any helsinkiad user that has these roles loses them when they login.

Removing this config should disable the role mapping for now.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10169-disable-ad-role-mapping`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Configure tunnistamo locally
* [ ] Add role to your user: `drush user:role:add 'comprehensive_school_editor' --uid <uid for your account>`
* [ ] Log in
* [ ] Check that `comprehensive_school_editor` role is preserved.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10281

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10169]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ