### PR TITLE
UHF-11057: Support address param in playground and daycare searches

### DIFF
--- a/conf/cmi/views.view.daycare_search.yml
+++ b/conf/cmi/views.view.daycare_search.yml
@@ -307,7 +307,7 @@ display:
             operator: address_search_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: address_search
+            identifier: address
             required: false
             remember: false
             multiple: false

--- a/conf/cmi/views.view.playground_search.yml
+++ b/conf/cmi/views.view.playground_search.yml
@@ -288,7 +288,7 @@ display:
             operator: address_search_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: address_search
+            identifier: address
             required: false
             remember: false
             multiple: false


### PR DESCRIPTION
# [UHF-11057](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11057)
<!-- What problem does this solve? -->

Testing info here: https://github.com/City-of-Helsinki/drupal-hdbt/pull/1161


[UHF-11057]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ