### PR TITLE
Automatic update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4300,16 +4300,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "6.9.11",
+            "version": "6.9.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "3128c16716abd0742fc70c0b5aed6224a75868af"
+                "reference": "d5be6d7bdb6d100566b603cfc0f66d904385b88d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/3128c16716abd0742fc70c0b5aed6224a75868af",
-                "reference": "3128c16716abd0742fc70c0b5aed6224a75868af",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/d5be6d7bdb6d100566b603cfc0f66d904385b88d",
+                "reference": "d5be6d7bdb6d100566b603cfc0f66d904385b88d",
                 "shasum": ""
             },
             "require": {
@@ -4328,10 +4328,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/6.9.11",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/6.9.12",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2025-02-04T14:07:34+00:00"
+            "time": "2025-02-05T07:19:52+00:00"
         },
         {
             "name": "drupal/hdbt_admin",


### PR DESCRIPTION

## [city-of-helsinki/drupal-hdbt](https://github.com/city-of-helsinki/drupal-hdbt): 6.9.11 to 6.9.12
### What's Changed
* [UHF-11396](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11396): Set error label level to 3 by default in https://github.com/City-of-Helsinki/drupal-hdbt/pull/1174


**Full Changelog**: https://github.com/City-of-Helsinki/drupal-hdbt/compare/6.9.11...6.9.12


[UHF-11396]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ