### PR TITLE
UHF-11326: Added aria-controls and aria-labelledby to group menu

### DIFF
--- a/public/modules/custom/helfi_group/templates/block--group-content-menu.html.twig
+++ b/public/modules/custom/helfi_group/templates/block--group-content-menu.html.twig
@@ -39,6 +39,9 @@
   {% set section_menu_title_current = null %}
 {% endif %}
 
+{% set section_menu_title_link = attributes.id ~ '-menu-link'|clean_id %}
+{% set section_menu_aria_controls = attributes.id ~ '-menu-wrapper'|clean_id %}
+
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }} class="sidebar-navigation sidebar-navigation--section-navigation">
   <div class="section-navigation__header">


### PR DESCRIPTION
# [UHF-11326](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11326)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added missing aria-controls and aria-labelledby to group menu

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11326 `
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to for example https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio/opiskelu/alppilan-monialaiset-tulevaisuustaidot and make sure that the sidebar menu has in mobile view aria-controls and aria-labelledby in the menu button
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation



[UHF-11326]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ