### PR TITLE
UHF-11315 School search

### DIFF
--- a/conf/cmi/search_api.index.schools.yml
+++ b/conf/cmi/search_api.index.schools.yml
@@ -127,7 +127,7 @@ processor_settings:
   entity_status: {  }
   entity_type: {  }
   helfi_kasko_content_additional_filters: {  }
-  is_school: {  }
+  helfi_kasko_content_is_school: {  }
   language_with_fallback: {  }
   media_reference_to_object:
     fields:

--- a/public/modules/custom/helfi_kasko_content/README.md
+++ b/public/modules/custom/helfi_kasko_content/README.md
@@ -1,0 +1,28 @@
+# City of Helsinki - Kasko Content
+
+## Kasko TPR Units
+
+The Kasko school search index is built using TPR Units, which are imported via the [helfi_tpr](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr?tab=readme-ov-file#drupal-tpr-integration) module. To ensure that only schools are included in the index, the [IsSchool](./src/Plugin/search_api/processor/IsSchool.php) Search API processor is used.
+
+### How the IsSchool Search API Processor works
+
+The **IsSchool** processor identifies schools by checking their assigned service IDs in the indexed TPR Units. It filters out any non-school entities.
+
+#### Recognized school service IDs:
+- **[3105](https://tpr.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/description/3105?newfeatures=yes&format=xml)**
+  - Translates to: *Luokkien 1-6 perusopetus* (Grades 1–6 Basic Education)
+- **[3106](https://tpr.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/description/3106?newfeatures=yes&format=xml)**
+  - Translates to: *Luokkien 7-9 perusopetus* (Grades 7–9 Basic Education)
+
+## Adding a new school to the index
+
+To add a new school to the **Schools index**, it must first be registered in TPR by a TPR administrator or client. The required tags for a TPR Unit are:
+
+- **"Suomenkielinen perusopetus luokille 1-6"** (Finnish-language basic education for grades 1–6)
+- **"Suomenkielinen perusopetus luokille 7-9"** (Finnish-language basic education for grades 7–9)
+
+These tags will be converted into the service IDs **3105** and **3106** in the TPR API.
+
+### Handling schools that are not automatically indexed
+
+In some cases, schools may not receive the correct service IDs in TPR, preventing them from appearing in the index. To manually adjust the indexing of such schools, use the **[School Settings](https://www.hel.fi/en/childhood-and-education/admin/config/school-settings)** page.

--- a/public/modules/custom/helfi_kasko_content/src/Form/SchoolSettingsForm.php
+++ b/public/modules/custom/helfi_kasko_content/src/Form/SchoolSettingsForm.php
@@ -53,6 +53,14 @@ class SchoolSettingsForm extends FormBase {
       '#description' => $this->t('Select the starting year for a comprehensive school year period. For example, selecting "2022" would set the school year to "2022-2023".'),
     ];
 
+    $form['additional_schools'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('List of additional schools to school index'),
+      '#default_value' => implode(',', SchoolUtility::getAdditionalSchools()),
+      '#description' => $this->t('Schools should be linked to the correct services in TPR, but in some cases, this is not possible. With this field, TPR units can be marked as schools in the school index by adding their IDs as a comma-separated list. Example: <code>1234,2345,3456</code>. <strong>Note!</strong> Elastic search index must be reindexed if the values are changed.', options: ['context' => 'helfi react search']),
+      '#rows' => 2,
+    ];
+
     $form['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Save'),
@@ -68,6 +76,7 @@ class SchoolSettingsForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     SchoolUtility::setCurrentHighSchoolYear(SchoolUtility::composeSchoolYear((int) $form_state->getValue('high_school_year_first')));
     SchoolUtility::setCurrentComprehensiveSchoolYear(SchoolUtility::composeSchoolYear((int) $form_state->getValue('comprehensive_school_year_first')));
+    SchoolUtility::setAdditionalSchools($form_state->getValue('additional_schools'));
   }
 
 }

--- a/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/IsSchool.php
+++ b/public/modules/custom/helfi_kasko_content/src/Plugin/search_api/processor/IsSchool.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_kasko_content\Plugin\search_api\processor;
 
-use Drupal\helfi_kasko_content\UnitCategoryUtility;
+use Drupal\helfi_kasko_content\SchoolUtility;
 use Drupal\helfi_react_search\SupportsUnitIndexTrait;
-use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\helfi_react_search\Plugin\search_api\processor\IsSchool as HelfiReactSearchIsSchool;
+use Drupal\search_api\Item\ItemInterface;
 
 /**
  * Checks if given TPR entity is a school.
  *
  * @SearchApiProcessor(
- *   id = "is_school",
+ *   id = "helfi_kasko_content_is_school",
  *   label = @Translation("School filter"),
  *   description = @Translation("Exclude non-school entities from index"),
  *   stages = {
@@ -20,23 +21,45 @@ use Drupal\search_api\Processor\ProcessorPluginBase;
  *   }
  * )
  */
-class IsSchool extends ProcessorPluginBase {
+class IsSchool extends HelfiReactSearchIsSchool {
 
   use SupportsUnitIndexTrait;
 
   /**
    * {@inheritdoc}
    */
-  public function alterIndexedItems(array &$items) {
-    /** @var \Drupal\search_api\Item\ItemInterface $item */
-    foreach ($items as $item_id => $item) {
-      $unit = $item->getOriginalObject()->getValue();
+  public function alterIndexedItems(array &$items): void {
+    foreach ($items as $id => $item) {
+      $shouldIndex = $this->shouldIndex($item);
 
-      if (!UnitCategoryUtility::entityHasCategory($unit, UnitCategoryUtility::COMPREHENSIVE_SCHOOL)) {
-        unset($items[$item_id]);
-        continue;
+      if (!$shouldIndex) {
+        unset($items[$id]);
       }
     }
+  }
+
+  /**
+   * Determine if entity should be indexed.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   Item to check.
+   *
+   * @return bool
+   *   The result.
+   *
+   * @throws \Drupal\search_api\SearchApiException
+   */
+  protected function shouldIndex(ItemInterface $item): bool {
+    // Return true if the TPR unit is school.
+    if (parent::shouldIndex($item)) {
+      return TRUE;
+    }
+
+    $object = $item->getOriginalObject()->getValue();
+    if (in_array($object->id(), SchoolUtility::getAdditionalSchools())) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
 }

--- a/public/modules/custom/helfi_kasko_content/src/SchoolUtility.php
+++ b/public/modules/custom/helfi_kasko_content/src/SchoolUtility.php
@@ -10,10 +10,11 @@ namespace Drupal\helfi_kasko_content;
 class SchoolUtility {
 
   /**
-   * School year key used with State API.
+   * School year key used with State API and additional schools.
    */
   private const HIGH_SCHOOL_YEAR_KEY = 'helfi_kasko_content.high_school_year';
   private const COMPREHENSIVE_SCHOOL_YEAR_KEY = 'helfi_kasko_content.comprehensive_school_year';
+  private const ADDITIONAL_SCHOOLS = 'helfi_kasko_content.additional_schools_to_school_index';
 
   /**
    * Helper function to get the current high school year.
@@ -36,6 +37,23 @@ class SchoolUtility {
   }
 
   /**
+   * Helper function to get the additional schools.
+   *
+   * @return array|null
+   *   The school IDs as an array.
+   */
+  public static function getAdditionalSchools(): ?array {
+    $schools = \Drupal::state()->get(self::ADDITIONAL_SCHOOLS);
+
+    if (empty($schools)) {
+      return NULL;
+    }
+
+    // Explode the string into an array and trim each element.
+    return array_map('trim', explode(',', $schools));
+  }
+
+  /**
    * Helper function to set the current high school year.
    *
    * @param string $schoolYear
@@ -53,6 +71,16 @@ class SchoolUtility {
    */
   public static function setCurrentComprehensiveSchoolYear(string $schoolYear) {
     \Drupal::state()->set(self::COMPREHENSIVE_SCHOOL_YEAR_KEY, $schoolYear);
+  }
+
+  /**
+   * Helper function to set the additional schools to school index.
+   *
+   * @param string $additionalSchools
+   *   A comma separated list of additional schools, e.g. "1234,2345,3456".
+   */
+  public static function setAdditionalSchools(string $additionalSchools) {
+    \Drupal::state()->set(self::ADDITIONAL_SCHOOLS, $additionalSchools);
   }
 
   /**


### PR DESCRIPTION
# [UHF-11315](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11315)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11315`
  * `make fresh`
* Run `make drush-cr`
* Run `make drush-cim` to update the School search index settings.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to edit the [school settings](https://helfi-kasko.docker.so/en/childhood-and-education/admin/config/school-settings) and add `6880, 7048` to the List of additional schools textarea.
   * [6880](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/admin/content/integrations/tpr-unit/6880) = Helsingin yliopiston Viikin normaalikoulu
   * [7048](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/admin/content/integrations/tpr-unit/7048) = Helsingin normaalilyseo
* [ ] After saving the settings, open shell and run `drush sapi-c; drush sapi-rt; drush sapi-i; drush cr`
* [ ] Check that the schools appear to [school search ](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/peruskoulut)
   * You can switch to "Etsi koulun tiedoilla" view, which makes it easier to find the schools. Use the word: `normaali`
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation
