### PR TITLE
UHF-11889 school editor announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,16 @@ KASKO has some additional fields on TPR units.
 Field categories is used to save the TPR unit categorization that is done based on the `ontologyword_ids`. Read more
 about it in the [TPR unit categorization section](#tpr-unit-categorization).
 
-### Announcements for user with role "comprehensive school editor"
+### Announcements for user with role "comprehensive school editor" and "school editor"
 
-Comprehensive school editor (peruskoulun sisällöntuottaja) can create, edit, translate and delete their own announcements.
+Comprehensive school editor (Peruskoulun sisällöntuottaja) can create, edit, translate and delete their own announcements.
 They can also see all unpublished announcements.
-An form alter has been created for announcement node. It prevents comprehensive school editor from creating a site wide announcement.
+A form alter has been created for announcement node. It prevents comprehensive school editor from creating a site wide announcement.
+
+School editor (Lukioiden sisällöntuottaja) can create, edit, translate and delete their own announcements.
+They can also see all unpublished announcements.
+The form alter allows school editor to creat announcements which are visible on the group's content pages.
+Announcement can be added to tpr units. Site wide announcements are prevented.
 
 #### [DEPRECATED] High school front page (field_hs_front_page)
 

--- a/conf/cmi/user.role.school_editor.yml
+++ b/conf/cmi/user.role.school_editor.yml
@@ -31,7 +31,7 @@ dependencies:
     - toolbar
     - view_unpublished
 id: school_editor
-label: 'Lukioiden sisällöntuottaja'
+label: 'Upper secondary school editor'
 weight: -4
 is_admin: null
 permissions:

--- a/conf/cmi/user.role.school_editor.yml
+++ b/conf/cmi/user.role.school_editor.yml
@@ -10,6 +10,7 @@ dependencies:
     - media.type.helfi_chart
     - media.type.image
     - media.type.remote_video
+    - node.type.announcement
     - node.type.landing_page
     - node.type.news_item
     - node.type.page
@@ -30,7 +31,7 @@ dependencies:
     - toolbar
     - view_unpublished
 id: school_editor
-label: 'Upper secondary school editor'
+label: 'Lukioiden sisällöntuottaja'
 weight: -4
 is_admin: null
 permissions:
@@ -42,6 +43,7 @@ permissions:
   - 'access user profiles'
   - 'cancel account'
   - 'change own username'
+  - 'create announcement content'
   - 'create file media'
   - 'create hel_map media'
   - 'create helfi_chart media'
@@ -49,6 +51,7 @@ permissions:
   - 'create media'
   - 'create remote_video media'
   - 'delete media'
+  - 'delete own announcement content'
   - 'delete own file media'
   - 'delete own files'
   - 'delete own hel_map media'
@@ -56,6 +59,7 @@ permissions:
   - 'delete own image media'
   - 'delete own remote_video media'
   - 'disable own tfa'
+  - 'edit own announcement content'
   - 'edit own file media'
   - 'edit own hel_map media'
   - 'edit own helfi_chart media'
@@ -65,6 +69,7 @@ permissions:
   - 'override landing_page published option'
   - 'override news_item published option'
   - 'override page published option'
+  - 'revert announcement revisions'
   - 'schedule publishing of nodes'
   - 'set news_item published on date'
   - 'setup own tfa'
@@ -73,6 +78,7 @@ permissions:
   - 'use text format full_html'
   - 'use text format minimal'
   - 'view all media revisions'
+  - 'view announcement revisions'
   - 'view any unpublished content'
   - 'view editoria11y checker'
   - 'view own unpublished content'

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -12,10 +12,13 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\UserSession;
 use Drupal\helfi_kasko_content\UnitCategoryUtility;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\group\Entity\GroupMembership;
 use Drupal\user\Entity\Role;
+
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -329,14 +332,21 @@ function helfi_kasko_content_views_data_alter(array &$data) {
  * Implements hook_form_FORM_ID_alter().
  */
 function helfi_kasko_content_form_node_announcement_form_alter(&$form): void {
-  _helfi_kasko_content_announcement_exception($form);
+  $account = \Drupal::currentUser()->getAccount();
+
+  _helfi_kasko_content_announcement_exception($form, $account);
+  _helfi_kasko_content_announcement_school_editor_exception($form, $account);
 }
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function helfi_kasko_content_form_node_announcement_edit_form_alter(&$form): void {
-  _helfi_kasko_content_announcement_exception($form);
+  /** @var \Drupal\user\Entity\User $account */
+  $account = \Drupal::currentUser()->getAccount();
+
+  _helfi_kasko_content_announcement_exception($form, $account);
+  _helfi_kasko_content_announcement_school_editor_exception($form, $account);
 }
 
 /**
@@ -348,10 +358,10 @@ function helfi_kasko_content_form_node_announcement_edit_form_alter(&$form): voi
  *
  * @param array $form
  *   The form.
+ * @param \Drupal\Core\Session\UserSession $account
+ *   The user account.
  */
-function _helfi_kasko_content_announcement_exception(array &$form): void {
-  /** @var \Drupal\user\Entity\User $account */
-  $account = \Drupal::currentUser()->getAccount();
+function _helfi_kasko_content_announcement_exception(array &$form, UserSession $account): void {
   $user_roles = $account->getRoles(TRUE);
   if (!in_array('comprehensive_school_editor', $user_roles)) {
     return;
@@ -367,7 +377,8 @@ function _helfi_kasko_content_announcement_exception(array &$form): void {
   // in that case, we don't want to alter anything.
   if (
     $account->hasRole('comprehensive_school_editor') &&
-    count($other_user_roles) >= 2
+    count($other_user_roles) >= 2 &&
+    !$account->hasRole('school_editor')
   ) {
     return;
   }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -440,8 +440,8 @@ function _helfi_kasko_content_announcement_school_editor_exception(array &$form,
   // Get all group related nodes and set them as announcement target pages.
   /** @var \Drupal\group\Entity\GroupMembership $membership */
   $membership = reset($groupMemberships);
-
   $entities = $membership->getGroup()->getRelatedEntities();
+
   $nodes = array_filter(
     $entities,
     fn($entity) =>
@@ -450,16 +450,23 @@ function _helfi_kasko_content_announcement_school_editor_exception(array &$form,
   );
   $node_ids = array_map(fn($entity) => $entity->id(), $nodes);
 
+  $units = array_filter(
+    $entities,
+    fn($entity) => $entity->getEntityTypeId() === 'tpr_unit'
+  );
+  $unit_ids = array_map(fn($entity) => $entity->id(), $units);
+
+  // Preset content pages.
   $info = t('The announcement will be shown on all pages related to your school.');
   $form['field_announcement_content_pages']['widget']['#default_value'] = $node_ids;
   $form['field_announcement_content_pages']['widget']['#description'] = $info;
   $form['field_announcement_content_pages']['#disabled'] = TRUE;
 
-  // May add units.
-  $info = t('Add the school you want to create the announcement for.');
-  $form['field_announcement_unit_pages']['widget']['#description'] = $info;
+  // Preset units.
+  $form['field_announcement_unit_pages']['widget']['#default_value'] = $unit_ids;
+  $form['field_announcement_unit_pages']['#disabled'] = TRUE;
 
-  // Prevent adding service pages (Palvelusivu) or content page (Sisältösivu).
+  // Prevent adding service pages (Palvelusivu)
   $form['field_announcement_service_pages']['#access'] = FALSE;
 
 }

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -438,7 +438,7 @@ function _helfi_kasko_content_announcement_school_editor_exception(array &$form,
   $form['field_announcement_all_pages']['#access'] = FALSE;
 
   // Get all group related nodes and set them as announcement target pages.
-  /** @var \Drupal\group\Entity\GroupMembership $group */
+  /** @var \Drupal\group\Entity\GroupMembership $membership */
   $membership = reset($groupMemberships);
 
   $entities = $membership->getGroup()->getRelatedEntities();

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -396,3 +396,66 @@ function _helfi_kasko_content_announcement_exception(array &$form, UserSession $
   $form['field_announcement_service_pages']['#access'] = FALSE;
   $form['field_announcement_content_pages']['#access'] = FALSE;
 }
+
+/**
+ * #UHF-11889 Allow school editors to create announcements for their group.
+ *
+ * Create announcement which is automatically targeted to all group content pages.
+ * Allow announcements for unit pages. Prevented site wide announcements.
+ *
+ * @param array $form
+ *   The form.
+ * @param \Drupal\Core\Session\UserSession $account
+ *   The user session.
+ */
+function _helfi_kasko_content_announcement_school_editor_exception(array &$form, \Drupal\Core\Session\UserSession $account): void {
+  $user_roles = $account->getRoles(TRUE);
+  if (!in_array('school_editor', $user_roles)) {
+    return;
+  }
+
+  $roles_with_permission = array_filter(
+    Role::loadMultiple(),
+    fn($role) => $role->hasPermission('create announcement content')
+  );
+  $other_user_roles = array_intersect(array_keys($roles_with_permission), $user_roles);
+
+  // User might have other roles than comprehensive school editor.
+  // in that case, we don't want to alter anything.
+  if (
+    $account->hasRole('school_editor') &&
+    count($other_user_roles) >= 2 &&
+    !in_array('comprehensive_school_editor', $other_user_roles)
+  ) {
+    return;
+  }
+
+  if (!$groupMemberships = GroupMembership::loadByUser($account)) {
+    return;
+  }
+
+  // Prevent from creating a site wide announcement.
+  $form['field_announcement_all_pages']['widget']['value']['#default_value'] = FALSE;
+  $form['field_announcement_all_pages']['#access'] = FALSE;
+
+  // Get all group related nodes and set them as announcement target pages.
+  /** @var \Drupal\group\Entity\GroupMembership $group */
+  $membership = reset($groupMemberships);
+
+  $entities = $membership->getGroup()->getRelatedEntities();
+  $nodes = array_filter($entities, fn($entity) => $entity->getEntityTypeId() === 'node');
+  $node_ids = array_map(fn($entity) => $entity->id(), $nodes);
+
+  $info = t('The announcement will be shown on all pages related to your school.');
+  $form['field_announcement_content_pages']['widget']['#default_value'] = $node_ids;
+  $form['field_announcement_content_pages']['widget']['#description'] = $info;
+  $form['field_announcement_content_pages']['#disabled'] = TRUE;
+
+  // May add units.
+  $info = t('Add the school you want to create the announcement for.');
+  $form['field_announcement_unit_pages']['widget']['#description'] = $info;
+
+  // Prevent adding service pages (Palvelusivu) or content page (Sisältösivu).
+  $form['field_announcement_service_pages']['#access'] = FALSE;
+
+}

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -330,7 +330,7 @@ function helfi_kasko_content_views_data_alter(array &$data) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function helfi_kasko_content_form_node_announcement_form_alter(&$form): void {
+function helfi_kasko_content_form_node_announcement_form_alter(&$form, $x): void {
   $account = \Drupal::currentUser()->getAccount();
 
   _helfi_kasko_content_announcement_exception($form, $account);
@@ -340,7 +340,7 @@ function helfi_kasko_content_form_node_announcement_form_alter(&$form): void {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function helfi_kasko_content_form_node_announcement_edit_form_alter(&$form): void {
+function helfi_kasko_content_form_node_announcement_edit_form_alter(&$form, $x): void {
   /** @var \Drupal\user\Entity\User $account */
   $account = \Drupal::currentUser()->getAccount();
 
@@ -442,7 +442,12 @@ function _helfi_kasko_content_announcement_school_editor_exception(array &$form,
   $membership = reset($groupMemberships);
 
   $entities = $membership->getGroup()->getRelatedEntities();
-  $nodes = array_filter($entities, fn($entity) => $entity->getEntityTypeId() === 'node');
+  $nodes = array_filter(
+    $entities,
+    fn($entity) =>
+      $entity->getEntityTypeId() === 'node' &&
+      $entity->bundle() !== 'news_item'
+  );
   $node_ids = array_map(fn($entity) => $entity->id(), $nodes);
 
   $info = t('The announcement will be shown on all pages related to your school.');

--- a/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
+++ b/public/modules/custom/helfi_kasko_content/helfi_kasko_content.module
@@ -19,7 +19,6 @@ use Drupal\paragraphs\ParagraphInterface;
 use Drupal\group\Entity\GroupMembership;
 use Drupal\user\Entity\Role;
 
-
 /**
  * Implements hook_ENTITY_TYPE_access().
  */
@@ -398,9 +397,9 @@ function _helfi_kasko_content_announcement_exception(array &$form, UserSession $
 }
 
 /**
- * #UHF-11889 Allow school editors to create announcements for their group.
+ * UHF-11889 Allow school editors to create announcements for their group.
  *
- * Create announcement which is automatically targeted to all group content pages.
+ * Create announcement which is automatically targeted to all group pages.
  * Allow announcements for unit pages. Prevented site wide announcements.
  *
  * @param array $form
@@ -408,7 +407,7 @@ function _helfi_kasko_content_announcement_exception(array &$form, UserSession $
  * @param \Drupal\Core\Session\UserSession $account
  *   The user session.
  */
-function _helfi_kasko_content_announcement_school_editor_exception(array &$form, \Drupal\Core\Session\UserSession $account): void {
+function _helfi_kasko_content_announcement_school_editor_exception(array &$form, UserSession $account): void {
   $user_roles = $account->getRoles(TRUE);
   if (!in_array('school_editor', $user_roles)) {
     return;


### PR DESCRIPTION
# [UHF-11889](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11889)

Allow school editor (Lukioiden sisällöntuottaja) to create announcements
- Automatically targeted to the group's content pages
- Automatically targeted the announcement to TPR-units
- Prevent site wide announcements
- Prevent adding service pages


## What was done
Created an alter. Updated permissions.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11889`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as a school editor
- Create an announcement
  - The announcement should be automatically targetet to all existing nodes linked to the group
  - TPR-services should be excluded
  - TPR-units should be possible
- Save the announcement and see that it is not visible outside of the group pages
- See that the announcement is visible on group pages.
- Check that the documentation makes sense

