### PR TITLE
patched whitescreen caused by group content menu -contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,9 @@
                 "https://www.drupal.org/project/group/issues/2815971": "https://www.drupal.org/files/issues/2023-06-13/group-context-2815971-46.patch",
                 "Duplicate revision(version) tab around Group's admin pages": "https://www.drupal.org/files/issues/2023-12-12/group-revision-tabs-appear-twice-3397063-15.patch"
             },
+            "drupal/group_content_menu":{
+                "Fix a whitescreen caused by merging array with null": "patches/merge_array_null.patch"
+            },
             "drupal/override_node_options": {
                 "Fix for Adding non-existent permissions to a role is not allowed error during site install.": "./patches/override_node_permissions_missing_dependencies.patch"
             }

--- a/patches/merge_array_null.patch
+++ b/patches/merge_array_null.patch
@@ -1,0 +1,13 @@
+diff --git a/src/NodeFormAlter.php b/src/NodeFormAlter.php
+index e22c063..3e1ffd0 100644
+--- a/src/NodeFormAlter.php
++++ b/src/NodeFormAlter.php
+@@ -216,7 +216,7 @@ class NodeFormAlter implements ContainerInjectionInterface {
+     $group_menu_parent_options = $this->menuParentSelector
+       ->getParentSelectOptions($defaults['id'], $group_menus);
+ 
+-    $traditional_menu_parent_options = $form['menu']['link']['menu_parent']['#options'];
++    $traditional_menu_parent_options = $form['menu']['link']['menu_parent']['#options'] ?? [];
+     $form['menu']['link']['menu_parent']['#options'] = $group_menu_parent_options + $traditional_menu_parent_options;
+ 
+     if (!empty($has_link_in_group_menus)) {


### PR DESCRIPTION
## What was done
Added a patch to fix whitecreen when trying to add content for a group

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_merge_array_null`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as a user with group (uid 771 for example)
- Go to group, add new content to group
- The content edit form should open without whitescreen

