### PR TITLE
UHF-11606: prevent duplicates in the group content views

### DIFF
--- a/conf/cmi/views.view.group_members.yml
+++ b/conf/cmi/views.view.group_members.yml
@@ -695,7 +695,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships:

--- a/conf/cmi/views.view.group_nodes.yml
+++ b/conf/cmi/views.view.group_nodes.yml
@@ -751,7 +751,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships:


### PR DESCRIPTION
# [UHF-11606](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11606)
Duplicates on group nodes and group members views.

## What was done
Added distinct option true on views query configuration

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11606`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as lukion sisällönsyöttäjä (For example `drush uli --uid=771`)
- Go to [group nodes](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/group/9/nodes) and [group members](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/group/9/members) views
- All the content used to be listed twice (check the PR screenshot)
  - Now the list should contain same item only once 


[UHF-11606]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ