### PR TITLE
UHF-12409: show only distinct news on groups news archive

### DIFF
--- a/conf/cmi/views.view.group_news_archive.yml
+++ b/conf/cmi/views.view.group_news_archive.yml
@@ -271,7 +271,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships:


### PR DESCRIPTION
# [UHF-12409](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12409)
Do not show duplicate values for logged in users

## What was done
Added the distinct: true

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12409_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as a group user (for example drush uli --uid=771)
- Go to the news archive page, for user 771 it would be:
  - /fi/kasvatus-ja-koulutus/makelanrinteen-lukio/makelanrinteen-lukion-uutiset
- The list should not show  duplicate news
