### PR TITLE
UHF-12582 Group cache rebuild after site install

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -7,7 +7,6 @@ on:
 name: Build artifacts
 jobs:
   build:
-    uses: city-of-helsinki/drupal-gh-actions/.github/workflows/build-artifact.yml@main
+    uses: city-of-helsinki/drupal-gh-actions/.github/workflows/build-artifact.yml@UHF-12582
     secrets:
       sentry_crons: ${{ secrets.SENTRY_CRONS }}
-

--- a/.github/workflows/update-config.yml
+++ b/.github/workflows/update-config.yml
@@ -5,6 +5,6 @@ on:
 name: Update config
 jobs:
   update-config:
-    uses: city-of-helsinki/drupal-gh-actions/.github/workflows/update-config.yml@main
+    uses: city-of-helsinki/drupal-gh-actions/.github/workflows/update-config.yml@UHF-12582
     secrets:
       automatic_update_token: ${{ secrets.AUTOMATIC_UPDATE_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,11 @@
         "patches": {
             "drupal/group": {
                 "https://www.drupal.org/project/group/issues/2815971": "./patches/2815971.patch",
-                "Duplicate revision(version) tab around Group's admin pages": "https://www.drupal.org/files/issues/2023-12-12/group-revision-tabs-appear-twice-3397063-15.patch"
+                "Duplicate revision(version) tab around Group's admin pages": "https://www.drupal.org/files/issues/2023-12-12/group-revision-tabs-appear-twice-3397063-15.patch",
+                "Fix for group relation type entity type definitions not available first cache rebuild after site install": "./patches/group_relation_type_entity_type_definitions_during_cache_rebuild.patch"
+            },
+            "drupal/group_content_menu": {
+                "Fix for group_content_menu derivative definition load during first cache rebuild after site install": "./patches/group_content_menu_derivative_definition_load_during_cache_rebuild.patch"
             },
             "drupal/override_node_options": {
                 "Fix for adding non-existent permissions to a role is not allowed error during site install.": "patches/override_node_permissions_missing_dependencies.patch"

--- a/patches/group_content_menu_derivative_definition_load_during_cache_rebuild.patch
+++ b/patches/group_content_menu_derivative_definition_load_during_cache_rebuild.patch
@@ -1,0 +1,27 @@
+diff --git a/src/Plugin/Group/Relation/GroupMenuDeriver.php b/src/Plugin/Group/Relation/GroupMenuDeriver.php
+index f7008f1..53d1a43 100644
+--- a/src/Plugin/Group/Relation/GroupMenuDeriver.php
++++ b/src/Plugin/Group/Relation/GroupMenuDeriver.php
+@@ -16,7 +16,21 @@ class GroupMenuDeriver extends DeriverBase {
+    * {@inheritdoc}
+    */
+   public function getDerivativeDefinitions($base_plugin_definition) {
+-    foreach (GroupContentMenuType::loadMultiple() as $name => $group_menu_type) {
++    $entity_type_manager = \Drupal::entityTypeManager();
++    if (!$entity_type_manager->hasDefinition('group_content_type')) {
++      return $this->derivatives;
++    }
++
++    try {
++      $types = GroupContentMenuType::loadMultiple();
++    }
++    catch (\Throwable $e) {
++      // Getting the derivative definitions during early container rebuilds
++      // or partial installs can cause errors.
++      return $this->derivatives;
++    }
++
++    foreach ($types as $name => $group_menu_type) {
+       $label = $group_menu_type->label();
+ 
+       $this->derivatives[$name] = clone $base_plugin_definition;

--- a/patches/group_relation_type_entity_type_definitions_during_cache_rebuild.patch
+++ b/patches/group_relation_type_entity_type_definitions_during_cache_rebuild.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Plugin/Group/Relation/GroupRelationTypeManager.php b/src/Plugin/Group/Relation/GroupRelationTypeManager.php
+index 4a405ea..d3f0f07 100644
+--- a/src/Plugin/Group/Relation/GroupRelationTypeManager.php
++++ b/src/Plugin/Group/Relation/GroupRelationTypeManager.php
+@@ -315,8 +315,15 @@ class GroupRelationTypeManager extends DefaultPluginManager implements GroupRela
+   public function installEnforced(?GroupTypeInterface $group_type = NULL) {
+     $enforced = [];
+ 
+-    // Gather the ID of all plugins that are marked as enforced.
+-    foreach ($this->getDefinitions() as $plugin_id => $group_relation_type) {
++    try {
++      $definitions = $this->getDefinitions();
++    }
++    catch (\Error $exception) {
++      // All group relation entity type definitions are not available during
++      // first cache rebuild after site install.
++      return;
++    }
++    foreach ($definitions as $plugin_id => $group_relation_type) {
+       assert($group_relation_type instanceof GroupRelationTypeInterface);
+       if ($group_relation_type->isEnforced()) {
+         $enforced[] = $plugin_id;

--- a/patches/group_relation_type_entity_type_definitions_during_cache_rebuild.patch
+++ b/patches/group_relation_type_entity_type_definitions_during_cache_rebuild.patch
@@ -1,11 +1,20 @@
 diff --git a/src/Plugin/Group/Relation/GroupRelationTypeManager.php b/src/Plugin/Group/Relation/GroupRelationTypeManager.php
-index 4a405ea..d3f0f07 100644
+index 4a405ea..982bbcd 100644
 --- a/src/Plugin/Group/Relation/GroupRelationTypeManager.php
 +++ b/src/Plugin/Group/Relation/GroupRelationTypeManager.php
+@@ -129,7 +129,7 @@ class GroupRelationTypeManager extends DefaultPluginManager implements GroupRela
+       throw new InvalidPluginDefinitionException($plugin_id, sprintf('The "%s" plugin defines entity access over group entities. This should be dealt with by altering the group permissions of the current user.', $plugin_id));
+     }
+
+-    if ($this->entityTypeManager->getDefinition($entity_type_id)->entityClassImplements(ConfigEntityInterface::class)) {
++    if ($this->entityTypeManager->getDefinition($entity_type_id, FALSE)->entityClassImplements(ConfigEntityInterface::class)) {
+       $definition->set('config_entity_type', TRUE);
+     }
+   }
 @@ -315,8 +315,15 @@ class GroupRelationTypeManager extends DefaultPluginManager implements GroupRela
    public function installEnforced(?GroupTypeInterface $group_type = NULL) {
      $enforced = [];
- 
+
 -    // Gather the ID of all plugins that are marked as enforced.
 -    foreach ($this->getDefinitions() as $plugin_id => $group_relation_type) {
 +    try {


### PR DESCRIPTION
# [UHF-12582](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12582)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Added patches to fix group related entity type definition loads during first cache rebuild after site install.

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Check that the [artifact build succeeds](https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/actions/workflows/artifact.yml)
* [ ] Check that the code follows our standards


[UHF-12582]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ