### PR TITLE
UHF-12785: Updating menu tree manipulator event subscriber to hide untranslated group menu items

### DIFF
--- a/public/modules/custom/helfi_group/src/EventSubscriber/GroupMenuFilterByLanguage.php
+++ b/public/modules/custom/helfi_group/src/EventSubscriber/GroupMenuFilterByLanguage.php
@@ -30,7 +30,7 @@ final class GroupMenuFilterByLanguage implements EventSubscriberInterface {
   }
 
   /**
-   * Responds to MenuLinkTreeEvents::ALTER_MANIPULATORS event.
+   * Responds to MenuLinkTreeManipulatorsAlterEvent event.
    *
    * @param \Drupal\Core\Menu\MenuLinkTreeManipulatorsAlterEvent $event
    *   The event to subscribe to.
@@ -40,7 +40,7 @@ final class GroupMenuFilterByLanguage implements EventSubscriberInterface {
       return;
     }
 
-    $manipulators = &$event->getManipulators();
+    $manipulators = $event->getManipulators();
 
     $menuName = NULL;
     foreach ($event->getTree() as $item) {
@@ -59,6 +59,8 @@ final class GroupMenuFilterByLanguage implements EventSubscriberInterface {
       'callable' => 'menu_block_current_language_tree_manipulator::filterLanguages',
       'args' => [['menu_link_content']],
     ];
+
+    $event->setManipulators($manipulators);
   }
 
   /**
@@ -66,7 +68,7 @@ final class GroupMenuFilterByLanguage implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() : array {
     return [
-      'menu.link_tree.alter_manipulators' => [
+      MenuLinkTreeManipulatorsAlterEvent::class => [
         ['filter'],
       ],
     ];

--- a/public/modules/custom/helfi_group/tests/src/Kernel/EventSubscriber/GroupMenuFilterByLanguageTest.php
+++ b/public/modules/custom/helfi_group/tests/src/Kernel/EventSubscriber/GroupMenuFilterByLanguageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_group\Tests\Kernel\EventSubscriber;
+
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\system\Entity\Menu;
+use Drupal\Tests\content_translation\Traits\ContentTranslationTestTrait;
+
+/**
+ * Tests the GroupMenuFilterByLanguage event subscriber.
+ */
+class GroupMenuFilterByLanguageTest extends EntityKernelTestBase {
+
+  use ContentTranslationTestTrait;
+
+  /**
+   * The tested menu link tree.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkTree
+   */
+  protected $linkTree;
+
+  /**
+   * The menu link plugin manager.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkManagerInterface
+   */
+  protected $menuLinkManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'menu_link_content',
+    'node',
+    'content_translation',
+    'link',
+    'helfi_group',
+    'menu_block_current_language',
+    'language',
+    'locale',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $type->save();
+
+    foreach (['fi', 'en'] as $langcode) {
+      $this->createLanguageFromLangcode($langcode);
+    }
+    $this->installConfig(['system', 'node']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('menu_link_content');
+
+    $this->enableContentTranslation('node', 'article');
+    $this->enableContentTranslation('menu_link_content', 'menu_link_content');
+
+    $this->linkTree = $this->container->get('menu.link_tree');
+    $this->menuLinkManager = $this->container->get('plugin.manager.menu.link');
+  }
+
+  /**
+   * Tests filtering out untranslated links.
+   */
+  public function testFilteringOutUntranslatedLinks(): void {
+    // Test node 1 only has Finnish translation.
+    $node1 = Node::create([
+      'type' => 'article',
+      'title' => 'Test node 1 in Finnish',
+      'body' => 'Test body',
+      'langcode' => 'fi',
+    ]);
+    $node1->save();
+
+    // Test node 2 has both Finnish and English translations.
+    $node2 = Node::create([
+      'type' => 'article',
+      'title' => 'Test node 2 in Finnish',
+      'body' => 'Test body',
+      'langcode' => 'fi',
+    ]);
+    $node2->addTranslation('en', [
+      'title' => 'Test node 2 in English',
+      'body' => 'Test body',
+    ]);
+    $node2->save();
+
+    Menu::create([
+      'id' => 'group_menu_link_content_1',
+      'label' => 'Test menu 1',
+      'description' => 'Test menu 1',
+    ])->save();
+
+    // Create content links for the nodes.
+    $contentLink1 = MenuLinkContent::create([
+      'link' => ['uri' => 'entity:node/' . $node1->id()],
+      'menu_name' => 'group_menu_link_content_1',
+      'title' => 'Test content link 1 in Finnish',
+      'langcode' => 'fi',
+    ]);
+    $contentLink1->save();
+
+    $contentLink2 = MenuLinkContent::create([
+      'link' => ['uri' => 'entity:node/' . $node2->id()],
+      'menu_name' => 'group_menu_link_content_1',
+      'title' => 'Test content link 2 in Finnish',
+      'langcode' => 'fi',
+    ]);
+    $contentLink2->save();
+    $contentLink2->addTranslation('en', [
+      'title' => 'Test content link 2 in English',
+      'body' => 'Test body',
+    ]);
+    $contentLink2->save();
+
+    $menu_tree = \Drupal::menuTree();
+    $tree = $menu_tree->load('group_menu_link_content_1', new MenuTreeParameters());
+    $tree = $menu_tree->transform($tree, []);
+    $build = $menu_tree->build($tree);
+
+    // Only menu link with English translation should be visible.
+    $this->assertArrayNotHasKey('menu_link_content:' . $contentLink1->uuid(), $build['#items']);
+    $this->assertArrayHasKey('menu_link_content:' . $contentLink2->uuid(), $build['#items']);
+  }
+
+}


### PR DESCRIPTION
# [UHF-12785](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12785)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* The menu tree manipulator event subscriber in `helfi_group` was updated to match the recently updated core patch from https://www.drupal.org/project/drupal/issues/3091246 (coming in through `helfi_platform_config`).

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12785`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [x] Go to https://helfi-kasko.docker.so/en/childhood-and-education/konepaja-upper-secondary-school-for-adults/finnish-courses ; you should only see English items on the left sidebar menu (you might see "Nuorten suunta studies", but it's actually the English translation for that link)
* [x] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

[UHF-12785]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ