### PR TITLE
UHF-12620: Fix result card url generation

### DIFF
--- a/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Controller/SearchController.php
+++ b/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Controller/SearchController.php
@@ -41,11 +41,17 @@ class SearchController extends ControllerBase {
 
     $eventsApiUrl = Url::fromUri($config->get('linked_events_api_url') . '/event', ['query' => $defaultOptions])->toString();
 
+    $availableLanguages = ['fi', 'sv', 'en'];
+
     return [
       '#attached' => [
         'drupalSettings' => [
           'helfi_events' => [
-            'baseUrl' => $this->environmentResolver->getActiveEnvironment()->getBaseUrl(),
+            'baseUrls' => array_reduce(
+              $availableLanguages,
+              fn(array $carry, string $language) => $carry + [$language => $this->environmentResolver->getActiveEnvironment()->getUrl($language)],
+              []
+            ),
             'data' => [
               'cross-institutional-studies-search' => [
                 'events_api_url' => $eventsApiUrl,

--- a/public/modules/custom/helfi_kasko_content/tests/src/Kernel/CrossInstitutionalStudies/Controller/SearchControllerTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Kernel/CrossInstitutionalStudies/Controller/SearchControllerTest.php
@@ -70,7 +70,7 @@ class SearchControllerTest extends KernelTestBase {
     $this->assertTrue($drupalSettings['useExperimentalGhosts']);
 
     $eventsSettings = $drupalSettings['helfi_events'];
-    $this->assertNotEmpty($eventsSettings['baseUrl']);
+    $this->assertNotEmpty($eventsSettings['baseUrls']);
 
     $searchData = $eventsSettings['data']['cross-institutional-studies-search'];
     $this->assertStringContainsString('linkedevents.api.test.hel.ninja', $searchData['events_api_url']);


### PR DESCRIPTION
# [UHF-12620](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12620)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fixes result card url generation


[UHF-12620]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ