### PR TITLE
UHF-12944: Show sibling sub-events for cross institutional studies

### DIFF
--- a/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Client.php
+++ b/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Client.php
@@ -87,6 +87,7 @@ class Client {
         array_map(static fn($language) => Language::tryFrom(basename(rtrim($language->{'@id'}, '/'))), $event->in_language ?? []),
         $event->min_capacity ?? NULL,
         $event->max_capacity ?? NULL,
+        isset($event->super_event->{'@id'}) ? basename(rtrim($event->super_event->{'@id'}, '/')) : NULL,
       );
     }
 

--- a/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Controller/Controller.php
+++ b/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/Controller/Controller.php
@@ -51,8 +51,24 @@ class Controller extends ControllerBase {
       "cross_institutional_studies:$id",
     ]);
 
+    // If this is a sub_event, fetch sibling sub_events from the super event.
+    $subEventIds = $event->sub_events;
+    if (empty($subEventIds) && $event->super_event) {
+      $cache->addCacheTags(["cross_institutional_studies:{$event->super_event}"]);
+
+      try {
+        $superEvents = $this->client->getEvent($event->super_event);
+
+        if ($superEvent = $superEvents[$langcode] ?? FALSE) {
+          $subEventIds = array_filter($superEvent->sub_events, fn (string $subEventId) => $subEventId !== $event->id);
+        }
+      }
+      catch (GuzzleException) {
+      }
+    }
+
     $subEvents = [];
-    foreach ($event->sub_events as $subEventId) {
+    foreach ($subEventIds as $subEventId) {
       $cache->addCacheTags(["cross_institutional_studies:$subEventId"]);
 
       try {

--- a/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/DTO/Event.php
+++ b/public/modules/custom/helfi_kasko_content/src/CrossInstitutionalStudies/DTO/Event.php
@@ -40,6 +40,8 @@ final readonly class Event {
    *   Minimum capacity of the event.
    * @param int|null $max_capacity
    *   Maximum capacity of the event.
+   * @param string|null $super_event
+   *   ID of the super event.
    */
   public function __construct(
     public string $id,
@@ -56,6 +58,7 @@ final readonly class Event {
     public array $in_language,
     public int|NULL $min_capacity,
     public int|NULL $max_capacity,
+    public string|NULL $super_event = NULL,
   ) {
   }
 

--- a/public/modules/custom/helfi_kasko_content/tests/src/Kernel/CrossInstitutionalStudies/Controller/ControllerTest.php
+++ b/public/modules/custom/helfi_kasko_content/tests/src/Kernel/CrossInstitutionalStudies/Controller/ControllerTest.php
@@ -16,11 +16,13 @@ use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests cross-institutional studies controller.
  */
 #[Group('helfi_kasko_content')]
+#[RunTestsInSeparateProcesses]
 class ControllerTest extends KernelTestBase {
 
   use ApiTestTrait;
@@ -117,6 +119,40 @@ class ControllerTest extends KernelTestBase {
   }
 
   /**
+   * Tests controller with a sub-event fetches siblings from super event.
+   */
+  public function testControllerWithSubEvent(): void {
+    $this->setUpCurrentUser(permissions: ['access content']);
+
+    $client = $this->createMockHttpClient([
+      // First request: the sub-event itself (gets cached).
+      new Response(200, [], $this->createEventResponse('sub-event-1', superEvent: 'parent-event')),
+      // Second request: the super event (to get sibling sub_events).
+      new Response(200, [], $this->createEventResponse('parent-event', ['sub-event-1', 'sub-event-2', 'sub-event-3'])),
+      // Third and fourth requests: sibling sub-events (sub-event-1
+      // is filtered out as current event).
+      new Response(200, [], $this->createEventResponse('sub-event-2', superEvent: 'parent-event')),
+      new Response(200, [], $this->createEventResponse('sub-event-3', superEvent: 'parent-event')),
+    ]);
+
+    $this->container->set('http_client', $client);
+
+    $request = $this->getMockedRequest(Url::fromRoute('helfi_kasko_content.cross_institutional_studies', [
+      'id' => 'sub-event-1',
+    ])->toString());
+
+    $response = $this->processRequest($request);
+
+    $this->assertEquals(200, $response->getStatusCode());
+    $content = $response->getContent();
+    $this->assertStringContainsString('Short description for sub-event-1', $content);
+    // Current event (sub-event-1) should not appear as a sub-event card link.
+    $this->assertStringNotContainsString('cross-institutional-studies/sub-event-1', $content);
+    $this->assertStringContainsString('Test Event sub-event-2', $content);
+    $this->assertStringContainsString('Test Event sub-event-3', $content);
+  }
+
+  /**
    * Tests language switcher hook for custom controller.
    */
   public function testLangSwitcher(): void {
@@ -155,8 +191,8 @@ class ControllerTest extends KernelTestBase {
   /**
    * Creates a mock event response.
    */
-  private function createEventResponse(string $id, array $subEvents = []): string {
-    return json_encode([
+  private function createEventResponse(string $id, array $subEvents = [], ?string $superEvent = NULL): string {
+    $data = [
       'id' => $id,
       'name' => (object) [
         'en' => "Test Event $id",
@@ -184,7 +220,13 @@ class ControllerTest extends KernelTestBase {
         static fn (string $subEventId) => (object) ['@id' => "https://linkedevents.api.test.hel.ninja/v1/event/$subEventId/"],
         $subEvents
       ),
-    ]);
+    ];
+
+    if ($superEvent) {
+      $data['super_event'] = (object) ['@id' => "https://linkedevents.api.test.hel.ninja/v1/event/$superEvent/"];
+    }
+
+    return json_encode($data);
   }
 
 }


### PR DESCRIPTION
# [UHF-12944](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12944)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
Show sibling sub-events for cross institutional studies

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12944`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

### Make sure you use production linked events api
Remove `linked_events_api_url` from `local.settings.php`:
```
// $config['helfi_kasko_content.settings']['linked_events_api_url'] = 'https://linkedevents.api.test.hel.ninja/v1';
``` 

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
Here is a course from linked events API: https://api.hel.fi/linkedevents/v1/event/helsinki:agny5jw3xq/.

* [ ] Check https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/ristiinopiskelu/helsinki:agny5jwsuu
  * [ ] You should see other implementations of the same course. 
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 


[UHF-12944]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ